### PR TITLE
Drop x86_64-apple-darwin from release matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,10 @@ jobs:
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             archive: tar.gz
-          - os: macos-13
-            target: x86_64-apple-darwin
-            archive: tar.gz
+          # x86_64-apple-darwin is omitted: macos-13 runner allocation has been
+          # unreliable since GitHub announced its deprecation, and Apple Silicon
+          # Macs can run the aarch64 binary natively. Add this target back once
+          # we have a stable Intel build path (or cross from arm64 via Zig/cc).
           - os: macos-latest
             target: aarch64-apple-darwin
             archive: tar.gz


### PR DESCRIPTION
## Summary

The v0.1.0 release run sat queued ~16 min waiting for a macos-13 runner
while every other target finished in 1-3 min. macos-13 has been winding
down since GitHub announced its deprecation. Removing this target unblocks
releases now; Apple Silicon Macs run the aarch64 build natively, so users on
arm64 macOS still have a binary. Intel-Mac users currently need to build
from source.

## Follow-up

- Add x86_64-apple-darwin back when we have a reliable Intel build path
  (cross-compile from macos-latest via Zig/cc, or a self-hosted Intel
  runner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)