### PR TITLE
Add manifest flow: pull from Bitwarden, push to GitHub + .env

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,11 +102,21 @@ For the manifest-driven flow:
 - The GitHub destination reads its token from `GH_TOKEN` (preferred) or
   `GITHUB_TOKEN`. There is no per-manifest token field by design — the
   manifest is checked in, the token is not.
-- The Bitwarden source shells out to the `bw` CLI. In a fresh environment
-  (CI) it expects `BW_CLIENTID`, `BW_CLIENTSECRET` (personal API key) and
-  `BW_PASSWORD` (master password) so it can `bw login --apikey` and
-  `bw unlock --raw --passwordenv BW_PASSWORD`. If `BW_SESSION` is already
-  set (e.g. local dev where the user is already unlocked), it's used as-is.
+- The Bitwarden source shells out to the `bw` (password-manager) CLI, which
+  must be on `$PATH` (`npm install -g @bitwarden/cli` or
+  `brew install bitwarden-cli`). In a fresh environment (CI) it expects
+  `BW_CLIENTID`, `BW_CLIENTSECRET` (personal API key) and `BW_PASSWORD`
+  (master password) so it can `bw login --apikey` and `bw unlock --raw
+  --passwordenv BW_PASSWORD`. The personal API key only *authenticates* — the
+  master password is still required to unlock the vault, so all three are
+  needed for a fresh login. If `BW_SESSION` is already set (e.g. local dev
+  where the user is already unlocked), it's used as-is and the other three are
+  ignored. Each credential is also read from a `BITWARDEN_*` alias when the
+  canonical `BW_*` name is unset: `BITWARDEN_CLIENT_ID`,
+  `BITWARDEN_CLIENT_SECRET`, `BITWARDEN_MASTER_PASSWORD` (or
+  `BITWARDEN_PASSWORD`), and `BITWARDEN_SESSION`. The canonical name wins when
+  both are set; an empty value counts as unset. The tool does **not** auto-load
+  a `.env` — export the vars first (e.g. `set -a; . .env; set +a`).
 - A second test-only override, `GH_SECRETS_TEST_SOURCE_FILE`, points the
   manifest's source resolver at a JSON file `{ "NAME": "value", ... }`
   instead of contacting Bitwarden. Used exclusively by `tests/e2e_manifest.rs`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,9 +10,21 @@ keep this file for constraints, tradeoffs, and judgment.
 ## What this repo is
 
 `gh-secrets` is a single-binary Rust CLI for managing GitHub Actions repository
-secrets in bulk. A user keeps a local config of profiles, included/excluded
-repositories, and global + per-repository secret values; `gh-secrets sync` then
-pushes only the secrets that have changed since the last sync.
+secrets in bulk. It has two distinct workflows:
+
+1. **Profile-based** (`gh-secrets token | repo | secrets | record | check`):
+   the user keeps a local config of profiles, included/excluded repositories,
+   and global + per-repository secret values; `gh-secrets secrets sync` then
+   pushes only the secrets that have changed since the last sync.
+
+2. **Manifest-based** (`gh-secrets manifest init|sync`): a repo-local
+   `gh-secrets.json` declares an external `source` (today: Bitwarden) and one
+   or more `destinations` (today: GitHub Actions secrets, dotenv file).
+   `gh-secrets manifest sync` pulls every managed secret from the source and
+   pushes to each destination that doesn't already hold the current value.
+   Idempotent across runs via a co-located `.gh-secrets-state.json`
+   (gitignore it) that stores per-(secret, destination) SHA-256 hashes — the
+   plaintext value is never persisted there.
 
 ## Command surface
 
@@ -79,6 +91,27 @@ The GitHub API base is `https://api.github.com` and is overridable for tests
 via `GH_SECRETS_API_BASE`. That override exists *only* so the e2e suite can
 point at `wiremock`; it is intentionally undocumented in `--help`.
 
+For the manifest-driven flow:
+
+- `gh-secrets.json` lives at the repo root (or wherever the user invokes
+  `gh-secrets manifest sync` against). It is checked into source control.
+- `.gh-secrets-state.json` sits next to it and stores per-(secret,
+  destination) SHA-256 hashes that drive the "push only when changed" check.
+  **Always gitignore this file** — losing it forces a re-push but leaks
+  nothing.
+- The GitHub destination reads its token from `GH_TOKEN` (preferred) or
+  `GITHUB_TOKEN`. There is no per-manifest token field by design — the
+  manifest is checked in, the token is not.
+- The Bitwarden source shells out to the `bw` CLI. In a fresh environment
+  (CI) it expects `BW_CLIENTID`, `BW_CLIENTSECRET` (personal API key) and
+  `BW_PASSWORD` (master password) so it can `bw login --apikey` and
+  `bw unlock --raw --passwordenv BW_PASSWORD`. If `BW_SESSION` is already
+  set (e.g. local dev where the user is already unlocked), it's used as-is.
+- A second test-only override, `GH_SECRETS_TEST_SOURCE_FILE`, points the
+  manifest's source resolver at a JSON file `{ "NAME": "value", ... }`
+  instead of contacting Bitwarden. Used exclusively by `tests/e2e_manifest.rs`
+  and intentionally undocumented in `--help`, mirroring `GH_SECRETS_API_BASE`.
+
 ## Scripts and output are context
 
 - Scripts and the CLI itself are quiet on success — a single line, or nothing.
@@ -108,6 +141,13 @@ point at `wiremock`; it is intentionally undocumented in `--help`.
   path runs end-to-end, and a local `secrets remove` does not delete the
   remote secret. The sandbox repo is shared across tests; isolation comes
   from a per-test secret-name prefix and a `Drop` cleanup.
+- The manifest-flow e2e suite (`tests/e2e_manifest.rs`) drives the binary
+  through `manifest init` and `manifest sync` end-to-end: pushes to GitHub
+  (wiremock) and a `.env` destination simultaneously; verifies the PUT body
+  is sealed-box shaped and the plaintext never appears in it; verifies a
+  re-sync of unchanged values produces zero new PUTs and zero env-file
+  writes; verifies a source-side value change repushes only the affected
+  secret. Bitwarden itself is unit-tested against a mock `BwCli`.
 
 ## Releases and CI secrets
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,6 +634,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -1533,6 +1534,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ dirs = "5.0"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "blocking"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sha2 = "0.10"
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/justfile
+++ b/justfile
@@ -24,7 +24,7 @@ test:
 # early-returns as a no-op when `GH_SECRETS_LIVE_TEST` is unset, so the gate
 # catches breakage in the live test code without paying for network calls.
 test-e2e:
-    cargo nextest run --test e2e --test e2e_live
+    cargo nextest run --test e2e --test e2e_manifest --test e2e_live
 
 # Live end-to-end tests against the real GitHub API. Requires `GH_TOKEN` with
 # `repo` scope (covers `secrets:write`); creates and reuses a private sandbox

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,11 +1,16 @@
+use std::path::PathBuf;
+
 use anyhow::{Context, Result};
 use clap::{Args, Parser, Subcommand};
 
 use crate::config::{load_active_profile, ProfileConfig};
+use crate::destinations::DestinationReport;
 use crate::github::GitHubClient;
+use crate::manifest::{RepoManifest, DEFAULT_MANIFEST_FILE};
 use crate::paths::Paths;
 use crate::secrets::Upsert;
 use crate::sync::{self, SyncReport};
+use crate::sync_manifest::{self, ManifestSyncReport};
 
 #[derive(Debug, Parser)]
 #[command(
@@ -47,6 +52,35 @@ enum Command {
     },
     /// Show which repositories aren't in the profile and which secrets are stale.
     Check,
+    /// Work with a repo-local `gh-secrets.json` manifest: pull from an external
+    /// source (Bitwarden) and push to one or more destinations (GitHub, env
+    /// file). Independent of the profile-based commands above.
+    Manifest {
+        #[command(subcommand)]
+        command: ManifestCmd,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum ManifestCmd {
+    /// Write a starter `gh-secrets.json` next to which `gh-secrets manifest
+    /// sync` can be invoked.
+    Init {
+        /// Where to write the manifest. Defaults to `./gh-secrets.json`.
+        #[arg(long, short)]
+        path: Option<PathBuf>,
+    },
+    /// Pull every managed secret from the manifest's source and push to each
+    /// destination that doesn't already hold the current value.
+    Sync {
+        /// Path to the manifest file. Defaults to `./gh-secrets.json`.
+        #[arg(long, short)]
+        config: Option<PathBuf>,
+        /// Path to the sync-state file. Defaults to `.gh-secrets-state.json`
+        /// next to the manifest.
+        #[arg(long)]
+        state: Option<PathBuf>,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -280,6 +314,22 @@ pub fn run() -> Result<()> {
         Command::Check => {
             check(&profile)?;
         }
+
+        Command::Manifest { command } => match command {
+            ManifestCmd::Init { path } => {
+                let target = path.unwrap_or_else(|| PathBuf::from(DEFAULT_MANIFEST_FILE));
+                if target.exists() {
+                    anyhow::bail!("{} already exists; refusing to overwrite", target.display());
+                }
+                RepoManifest::starter().save(&target)?;
+                println!("manifest: wrote starter to {}", target.display());
+            }
+            ManifestCmd::Sync { config, state } => {
+                let manifest_path = config.unwrap_or_else(|| PathBuf::from(DEFAULT_MANIFEST_FILE));
+                let report = sync_manifest::sync_manifest(&manifest_path, state.as_deref())?;
+                print_manifest_report(&report);
+            }
+        },
     }
 
     if profile_dirty {
@@ -306,6 +356,31 @@ fn scope_label(repo: Option<&str>) -> String {
         Some(r) => format!("repo '{r}'"),
         None => "global".to_string(),
     }
+}
+
+fn print_manifest_report(report: &ManifestSyncReport) {
+    if report.is_noop() {
+        println!("manifest sync: nothing to do");
+        return;
+    }
+    for outcome in &report.destinations {
+        print_destination_report(&outcome.destination_key, &outcome.report);
+    }
+}
+
+fn print_destination_report(key: &str, report: &DestinationReport) {
+    for name in &report.created {
+        println!("{key}: created '{name}'");
+    }
+    for name in &report.updated {
+        println!("{key}: updated '{name}'");
+    }
+    println!(
+        "{key}: {} created, {} updated, {} unchanged",
+        report.created.len(),
+        report.updated.len(),
+        report.unchanged.len()
+    );
 }
 
 fn print_sync_report(report: &SyncReport) {

--- a/src/destinations.rs
+++ b/src/destinations.rs
@@ -1,0 +1,436 @@
+//! Sync destinations: where the orchestrator pushes values to.
+//!
+//! Two concrete impls today:
+//! - `GitHubDestination` — wraps the existing GitHub Actions secrets client,
+//!   uses `GH_TOKEN` / `GITHUB_TOKEN` for auth.
+//! - `EnvFileDestination` — writes a dotenv-style file, preserving unrelated
+//!   lines and (on Unix) tightening file mode to 0600.
+
+use std::collections::BTreeMap;
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Context, Result};
+
+use crate::github::GitHubClient;
+use crate::manifest::{EnvFileDestinationConfig, GithubDestinationConfig};
+use crate::sync;
+
+/// One value the orchestrator wants pushed, with everything the destination
+/// needs to decide whether the push is a no-op.
+#[derive(Debug, Clone)]
+pub struct DestinationEntry {
+    pub name: String,
+    pub value: String,
+    pub current_hash: String,
+    pub last_pushed_hash: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct DestinationRequest {
+    pub entries: Vec<DestinationEntry>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DestinationReport {
+    pub created: Vec<String>,
+    pub updated: Vec<String>,
+    pub unchanged: Vec<String>,
+}
+
+impl DestinationReport {
+    pub fn changed(&self) -> bool {
+        !self.created.is_empty() || !self.updated.is_empty()
+    }
+}
+
+/// What a destination knows how to do: identify itself (so the state file can
+/// key on it) and apply a batch of updates.
+pub trait Destination {
+    fn key(&self) -> String;
+    fn apply(&mut self, request: DestinationRequest) -> Result<DestinationReport>;
+}
+
+// ---- GitHub ----
+
+pub const GITHUB_TOKEN_ENVS: &[&str] = &["GH_TOKEN", "GITHUB_TOKEN"];
+
+pub struct GitHubDestination {
+    repository: String,
+    client: GitHubClient,
+}
+
+impl GitHubDestination {
+    pub fn from_config(config: &GithubDestinationConfig) -> Result<Self> {
+        let token = github_token_from_env()?;
+        let client = GitHubClient::new(&token).context("building GitHub client")?;
+        Ok(Self {
+            repository: config.repository.clone(),
+            client,
+        })
+    }
+
+    pub fn with_client(repository: String, client: GitHubClient) -> Self {
+        Self { repository, client }
+    }
+}
+
+pub fn github_token_from_env() -> Result<String> {
+    for name in GITHUB_TOKEN_ENVS {
+        if let Ok(v) = env::var(name) {
+            if !v.is_empty() {
+                return Ok(v);
+            }
+        }
+    }
+    Err(anyhow!(
+        "no GitHub token in environment; set one of: {}",
+        GITHUB_TOKEN_ENVS.join(", ")
+    ))
+}
+
+impl Destination for GitHubDestination {
+    fn key(&self) -> String {
+        format!("github:{}", self.repository)
+    }
+
+    fn apply(&mut self, request: DestinationRequest) -> Result<DestinationReport> {
+        let mut report = DestinationReport::default();
+        // Lazily fetch the public key — only if we have at least one push.
+        let mut public_key: Option<crate::github::RepoPublicKey> = None;
+        for entry in &request.entries {
+            if entry.last_pushed_hash.as_deref() == Some(&entry.current_hash) {
+                report.unchanged.push(entry.name.clone());
+                continue;
+            }
+            if public_key.is_none() {
+                public_key = Some(
+                    self.client
+                        .get_public_key(&self.repository)
+                        .with_context(|| format!("fetching public key for {}", self.repository))?,
+                );
+            }
+            let key = public_key.as_ref().expect("public key set above");
+            let ct = sync::seal(&key.key, &entry.value)
+                .with_context(|| format!("encrypting '{}' for {}", entry.name, self.repository))?;
+            let created = self
+                .client
+                .put_secret(&self.repository, &entry.name, &ct, &key.key_id)
+                .with_context(|| format!("uploading '{}' to {}", entry.name, self.repository))?;
+            if created {
+                report.created.push(entry.name.clone());
+            } else {
+                report.updated.push(entry.name.clone());
+            }
+        }
+        Ok(report)
+    }
+}
+
+// ---- Env file ----
+
+pub struct EnvFileDestination {
+    pub path: PathBuf,
+    /// State-file key derived from the manifest's (possibly relative) path so
+    /// it stays stable across invocations regardless of the absolute resolved
+    /// location of `path`.
+    key: String,
+}
+
+impl EnvFileDestination {
+    pub fn from_config(config: &EnvFileDestinationConfig, base_dir: &std::path::Path) -> Self {
+        let path = if config.path.is_absolute() {
+            config.path.clone()
+        } else {
+            base_dir.join(&config.path)
+        };
+        let key = format!("env_file:{}", config.path.display());
+        Self { path, key }
+    }
+}
+
+impl Destination for EnvFileDestination {
+    fn key(&self) -> String {
+        self.key.clone()
+    }
+
+    fn apply(&mut self, request: DestinationRequest) -> Result<DestinationReport> {
+        let existing = if self.path.exists() {
+            fs::read_to_string(&self.path)
+                .with_context(|| format!("reading {}", self.path.display()))?
+        } else {
+            String::new()
+        };
+
+        let mut lines: Vec<String> = if existing.is_empty() {
+            Vec::new()
+        } else {
+            existing.split('\n').map(String::from).collect()
+        };
+        // If the file ended with a trailing newline, `split` produced a trailing
+        // empty element. Drop it so we don't double up newlines on rewrite.
+        if existing.ends_with('\n') {
+            lines.pop();
+        }
+
+        let mut key_to_index: BTreeMap<String, usize> = BTreeMap::new();
+        for (i, line) in lines.iter().enumerate() {
+            if let Some(k) = parse_env_key(line) {
+                key_to_index.insert(k, i);
+            }
+        }
+
+        let mut report = DestinationReport::default();
+        let mut changed = false;
+
+        for entry in &request.entries {
+            let new_line = format_env_line(&entry.name, &entry.value);
+            let already_present = key_to_index.contains_key(&entry.name);
+            // We only treat this as truly unchanged when the file already has
+            // the key AND the state says we last pushed this exact hash. Either
+            // missing means the user (or another tool) edited the file out from
+            // under us; rewrite.
+            let state_matches = entry.last_pushed_hash.as_deref() == Some(&entry.current_hash);
+            if already_present && state_matches {
+                // Make sure the line is exactly what we'd write today — if not,
+                // overwrite (handles a user-edited line).
+                let idx = key_to_index[&entry.name];
+                if lines[idx] == new_line {
+                    report.unchanged.push(entry.name.clone());
+                    continue;
+                }
+                lines[idx] = new_line;
+                report.updated.push(entry.name.clone());
+                changed = true;
+                continue;
+            }
+
+            match key_to_index.get(&entry.name).copied() {
+                Some(idx) => {
+                    if lines[idx] != new_line {
+                        lines[idx] = new_line;
+                        changed = true;
+                    }
+                    report.updated.push(entry.name.clone());
+                }
+                None => {
+                    lines.push(new_line);
+                    // Update the index in case a later entry has the same name
+                    // (shouldn't happen, but be safe).
+                    key_to_index.insert(entry.name.clone(), lines.len() - 1);
+                    report.created.push(entry.name.clone());
+                    changed = true;
+                }
+            }
+        }
+
+        if changed {
+            let mut body = lines.join("\n");
+            body.push('\n');
+            write_env_file(&self.path, &body)?;
+        }
+        Ok(report)
+    }
+}
+
+fn write_env_file(path: &std::path::Path, body: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+        }
+    }
+    let tmp = match path.extension().and_then(|s| s.to_str()) {
+        Some(ext) => path.with_extension(format!("{ext}.tmp")),
+        None => path.with_extension("tmp"),
+    };
+    fs::write(&tmp, body).with_context(|| format!("writing {}", tmp.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = fs::Permissions::from_mode(0o600);
+        fs::set_permissions(&tmp, perms)
+            .with_context(|| format!("setting 0600 perms on {} before rename", tmp.display()))?;
+    }
+    fs::rename(&tmp, path)
+        .with_context(|| format!("renaming {} -> {}", tmp.display(), path.display()))?;
+    Ok(())
+}
+
+/// Pull the `KEY` out of `KEY=value` (optionally prefixed by `export `).
+/// Whitespace-tolerant on the left. Returns `None` for blank lines, comments,
+/// or anything that doesn't look like an env assignment.
+pub fn parse_env_key(line: &str) -> Option<String> {
+    let trimmed = line.trim_start();
+    if trimmed.is_empty() || trimmed.starts_with('#') {
+        return None;
+    }
+    let rest = trimmed
+        .strip_prefix("export ")
+        .map(str::trim_start)
+        .unwrap_or(trimmed);
+    let eq = rest.find('=')?;
+    let key = rest[..eq].trim_end();
+    if key.is_empty() {
+        return None;
+    }
+    if !key
+        .chars()
+        .next()
+        .map(|c| c.is_ascii_alphabetic() || c == '_')
+        .unwrap_or(false)
+    {
+        return None;
+    }
+    if !key.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+        return None;
+    }
+    Some(key.to_string())
+}
+
+/// Render `KEY=value` for an env file using double-quoted form with escapes
+/// chosen so dotenv-style parsers (and Bash via `set -a; source file`) read
+/// back the same value, while preventing variable expansion of `$`.
+pub fn format_env_line(name: &str, value: &str) -> String {
+    let mut quoted = String::with_capacity(value.len() + 2);
+    quoted.push('"');
+    for c in value.chars() {
+        match c {
+            '\\' => quoted.push_str("\\\\"),
+            '"' => quoted.push_str("\\\""),
+            '$' => quoted.push_str("\\$"),
+            '`' => quoted.push_str("\\`"),
+            '\n' => quoted.push_str("\\n"),
+            '\r' => quoted.push_str("\\r"),
+            '\t' => quoted.push_str("\\t"),
+            _ => quoted.push(c),
+        }
+    }
+    quoted.push('"');
+    format!("{name}={quoted}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn parse_env_key_handles_basic_cases() {
+        assert_eq!(parse_env_key("FOO=bar"), Some("FOO".into()));
+        assert_eq!(parse_env_key("  FOO=bar"), Some("FOO".into()));
+        assert_eq!(parse_env_key("export FOO=bar"), Some("FOO".into()));
+        assert_eq!(parse_env_key("FOO = bar"), Some("FOO".into()));
+        assert_eq!(parse_env_key("# FOO=bar"), None);
+        assert_eq!(parse_env_key(""), None);
+        assert_eq!(parse_env_key("1FOO=bar"), None);
+        assert_eq!(parse_env_key("foo-bar=1"), None);
+    }
+
+    #[test]
+    fn format_env_line_escapes_safely() {
+        assert_eq!(format_env_line("K", "v"), r#"K="v""#);
+        assert_eq!(format_env_line("K", r#"a"b\c$d`e"#), r#"K="a\"b\\c\$d\`e""#);
+        assert_eq!(format_env_line("K", "a\nb\tc"), r#"K="a\nb\tc""#);
+    }
+
+    fn entry(name: &str, value: &str, last: Option<&str>) -> DestinationEntry {
+        let current_hash = crate::manifest::value_hash(name, value);
+        DestinationEntry {
+            name: name.to_string(),
+            value: value.to_string(),
+            current_hash,
+            last_pushed_hash: last.map(String::from),
+        }
+    }
+
+    #[test]
+    fn env_file_creates_new_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("out.env");
+        let mut dest = EnvFileDestination {
+            path: path.clone(),
+            key: format!("env_file:{}", path.display()),
+        };
+        let report = dest
+            .apply(DestinationRequest {
+                entries: vec![entry("FOO", "bar", None)],
+            })
+            .unwrap();
+        assert_eq!(report.created, vec!["FOO"]);
+        assert!(report.updated.is_empty());
+        let content = fs::read_to_string(&path).unwrap();
+        assert_eq!(content, "FOO=\"bar\"\n");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = fs::metadata(&path).unwrap().permissions().mode();
+            assert_eq!(mode & 0o777, 0o600);
+        }
+    }
+
+    #[test]
+    fn env_file_preserves_foreign_lines() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("out.env");
+        fs::write(&path, "# comment\nOTHER=keepme\nFOO=old\nTRAILING=keep\n").unwrap();
+        let mut dest = EnvFileDestination {
+            path: path.clone(),
+            key: format!("env_file:{}", path.display()),
+        };
+        let report = dest
+            .apply(DestinationRequest {
+                entries: vec![entry("FOO", "new", None), entry("BAR", "added", None)],
+            })
+            .unwrap();
+        assert_eq!(report.updated, vec!["FOO"]);
+        assert_eq!(report.created, vec!["BAR"]);
+        let content = fs::read_to_string(&path).unwrap();
+        assert_eq!(
+            content,
+            "# comment\nOTHER=keepme\nFOO=\"new\"\nTRAILING=keep\nBAR=\"added\"\n"
+        );
+    }
+
+    #[test]
+    fn env_file_skips_when_state_matches_and_file_already_has_value() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("out.env");
+        let h = crate::manifest::value_hash("FOO", "bar");
+        fs::write(&path, "FOO=\"bar\"\n").unwrap();
+        let mut dest = EnvFileDestination {
+            path: path.clone(),
+            key: format!("env_file:{}", path.display()),
+        };
+        let report = dest
+            .apply(DestinationRequest {
+                entries: vec![entry("FOO", "bar", Some(&h))],
+            })
+            .unwrap();
+        assert_eq!(report.unchanged, vec!["FOO"]);
+        assert!(!report.changed());
+    }
+
+    #[test]
+    fn env_file_rewrites_when_file_was_edited_even_if_state_matches() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("out.env");
+        let h = crate::manifest::value_hash("FOO", "bar");
+        // User edited the file to something else.
+        fs::write(&path, "FOO=tampered\n").unwrap();
+        let mut dest = EnvFileDestination {
+            path: path.clone(),
+            key: format!("env_file:{}", path.display()),
+        };
+        let report = dest
+            .apply(DestinationRequest {
+                entries: vec![entry("FOO", "bar", Some(&h))],
+            })
+            .unwrap();
+        // The fact that state hash matches doesn't matter — file content
+        // differs from canonical form, so we rewrite.
+        assert_eq!(report.updated, vec!["FOO"]);
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(content.contains("FOO=\"bar\""));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,11 @@
 
 pub mod cli;
 pub mod config;
+pub mod destinations;
 pub mod github;
+pub mod manifest;
 pub mod paths;
 pub mod secrets;
+pub mod sources;
 pub mod sync;
+pub mod sync_manifest;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,0 +1,283 @@
+//! Repo-local manifest config + sync-state types.
+//!
+//! Two files live next to each other (typically at the repo root):
+//!
+//! - `gh-secrets.json` — checked-in manifest: source, list of secrets to
+//!   manage, list of destinations to push to.
+//! - `.gh-secrets-state.json` — gitignored, stores per-secret, per-destination
+//!   SHA-256 hashes so we can do "push only when something changed" without
+//!   ever persisting the plaintext value.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+pub const DEFAULT_MANIFEST_FILE: &str = "gh-secrets.json";
+pub const DEFAULT_STATE_FILE: &str = ".gh-secrets-state.json";
+
+/// One secret managed by the manifest. `item` defaults to `name` when omitted
+/// (i.e. the source's identifier matches the secret name). `field` defaults to
+/// the source's own default (typically `password` for Bitwarden logins).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ManifestSecret {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub item: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub field: Option<String>,
+}
+
+impl ManifestSecret {
+    /// The identifier passed to the source for lookup.
+    pub fn source_item(&self) -> &str {
+        self.item.as_deref().unwrap_or(&self.name)
+    }
+}
+
+/// What kind of source the manifest pulls from. Tagged on `type` so we can add
+/// further providers without breaking older configs.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ManifestSource {
+    Bitwarden(BitwardenSourceConfig),
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BitwardenSourceConfig {
+    /// Optional collection ID to scope lookups to.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub collection_id: Option<String>,
+    /// Optional organization ID to scope lookups to.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization_id: Option<String>,
+    /// Default field to extract when a secret doesn't specify one. Defaults to
+    /// `password` (matching a Bitwarden Login item).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_field: Option<String>,
+}
+
+/// One sync destination. Tagged on `type` for forward-compat.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ManifestDestination {
+    Github(GithubDestinationConfig),
+    EnvFile(EnvFileDestinationConfig),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GithubDestinationConfig {
+    /// `owner/repo`.
+    pub repository: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EnvFileDestinationConfig {
+    /// Path to the env file, relative to the manifest's directory unless
+    /// absolute.
+    pub path: PathBuf,
+}
+
+impl ManifestDestination {
+    /// Stable identifier used as a key in `SyncState` so adding/removing
+    /// destinations doesn't reset every secret's state.
+    pub fn key(&self) -> String {
+        match self {
+            ManifestDestination::Github(c) => format!("github:{}", c.repository),
+            ManifestDestination::EnvFile(c) => format!("env_file:{}", c.path.display()),
+        }
+    }
+}
+
+/// The full manifest, loaded from `gh-secrets.json`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RepoManifest {
+    pub source: ManifestSource,
+    #[serde(default)]
+    pub secrets: Vec<ManifestSecret>,
+    #[serde(default)]
+    pub destinations: Vec<ManifestDestination>,
+}
+
+impl RepoManifest {
+    pub fn starter() -> Self {
+        Self {
+            source: ManifestSource::Bitwarden(BitwardenSourceConfig::default()),
+            secrets: vec![ManifestSecret {
+                name: "EXAMPLE_SECRET".into(),
+                item: Some("example-bitwarden-item-name-or-id".into()),
+                field: None,
+            }],
+            destinations: vec![
+                ManifestDestination::Github(GithubDestinationConfig {
+                    repository: "owner/repo".into(),
+                }),
+                ManifestDestination::EnvFile(EnvFileDestinationConfig {
+                    path: PathBuf::from(".env"),
+                }),
+            ],
+        }
+    }
+
+    pub fn load(path: &Path) -> Result<Self> {
+        let bytes = fs::read(path).with_context(|| format!("reading {}", path.display()))?;
+        serde_json::from_slice(&bytes).with_context(|| format!("parsing {}", path.display()))
+    }
+
+    pub fn save(&self, path: &Path) -> Result<()> {
+        let bytes = serde_json::to_vec_pretty(self).context("serializing manifest")?;
+        write_atomic(path, &bytes)
+    }
+}
+
+/// Sync state co-located with the manifest. Keyed `secret_name -> destination
+/// key -> SHA-256 of the last value we successfully pushed there`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SyncState {
+    #[serde(default)]
+    pub secrets: BTreeMap<String, SecretSyncState>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SecretSyncState {
+    /// Hash of the last value we observed from the source.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_hash: Option<String>,
+    /// Per-destination hash of the last value we successfully pushed.
+    #[serde(default)]
+    pub destinations: BTreeMap<String, String>,
+}
+
+impl SyncState {
+    pub fn load_or_default(path: &Path) -> Result<Self> {
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+        let bytes = fs::read(path).with_context(|| format!("reading {}", path.display()))?;
+        serde_json::from_slice(&bytes).with_context(|| format!("parsing {}", path.display()))
+    }
+
+    pub fn save(&self, path: &Path) -> Result<()> {
+        let bytes = serde_json::to_vec_pretty(self).context("serializing sync state")?;
+        write_atomic(path, &bytes)
+    }
+
+    pub fn last_pushed_hash(&self, name: &str, destination_key: &str) -> Option<&str> {
+        self.secrets
+            .get(name)
+            .and_then(|s| s.destinations.get(destination_key))
+            .map(String::as_str)
+    }
+
+    pub fn record_push(&mut self, name: &str, destination_key: &str, hash: &str) {
+        let entry = self.secrets.entry(name.to_string()).or_default();
+        entry
+            .destinations
+            .insert(destination_key.to_string(), hash.to_string());
+    }
+
+    pub fn record_source(&mut self, name: &str, hash: &str) {
+        let entry = self.secrets.entry(name.to_string()).or_default();
+        entry.source_hash = Some(hash.to_string());
+    }
+}
+
+/// SHA-256 of `name + NUL + value`, hex-encoded. Domain-separated so renaming a
+/// secret never reuses a stale hash from a different name.
+pub fn value_hash(name: &str, value: &str) -> String {
+    let mut h = Sha256::new();
+    h.update(name.as_bytes());
+    h.update([0u8]);
+    h.update(value.as_bytes());
+    let digest = h.finalize();
+    hex_lower(&digest)
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push(HEX[(b >> 4) as usize] as char);
+        out.push(HEX[(b & 0xf) as usize] as char);
+    }
+    out
+}
+
+fn write_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+        }
+    }
+    let tmp = match path.extension().and_then(|s| s.to_str()) {
+        Some(ext) => path.with_extension(format!("{ext}.tmp")),
+        None => path.with_extension("tmp"),
+    };
+    fs::write(&tmp, bytes).with_context(|| format!("writing {}", tmp.display()))?;
+    fs::rename(&tmp, path)
+        .with_context(|| format!("renaming {} -> {}", tmp.display(), path.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manifest_round_trip_json() {
+        let m = RepoManifest::starter();
+        let s = serde_json::to_string_pretty(&m).unwrap();
+        let back: RepoManifest = serde_json::from_str(&s).unwrap();
+        assert_eq!(m, back);
+    }
+
+    #[test]
+    fn destination_key_is_stable_and_unique() {
+        let a = ManifestDestination::Github(GithubDestinationConfig {
+            repository: "o/r".into(),
+        });
+        let b = ManifestDestination::EnvFile(EnvFileDestinationConfig {
+            path: PathBuf::from(".env"),
+        });
+        assert_eq!(a.key(), "github:o/r");
+        assert_eq!(b.key(), "env_file:.env");
+        assert_ne!(a.key(), b.key());
+    }
+
+    #[test]
+    fn source_item_defaults_to_name() {
+        let s = ManifestSecret {
+            name: "FOO".into(),
+            item: None,
+            field: None,
+        };
+        assert_eq!(s.source_item(), "FOO");
+        let s2 = ManifestSecret {
+            name: "FOO".into(),
+            item: Some("foo-bw".into()),
+            field: None,
+        };
+        assert_eq!(s2.source_item(), "foo-bw");
+    }
+
+    #[test]
+    fn value_hash_is_domain_separated() {
+        assert_ne!(value_hash("A", "BC"), value_hash("AB", "C"));
+        assert_eq!(value_hash("X", "Y"), value_hash("X", "Y"));
+    }
+
+    #[test]
+    fn sync_state_round_trip() {
+        let mut s = SyncState::default();
+        s.record_source("FOO", "deadbeef");
+        s.record_push("FOO", "github:o/r", "cafebabe");
+        let bytes = serde_json::to_vec(&s).unwrap();
+        let back: SyncState = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(s, back);
+        assert_eq!(back.last_pushed_hash("FOO", "github:o/r"), Some("cafebabe"));
+        assert_eq!(back.last_pushed_hash("FOO", "env_file:.env"), None);
+    }
+}

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -72,10 +72,35 @@ impl SecretSource for StaticSource {
 
 // ---- Bitwarden ----
 
+/// Canonical env var names passed through to the `bw` subprocess. These match
+/// the Bitwarden CLI's own convention, so anything `bw` reads natively keeps
+/// working.
 pub const BW_CLIENTID_ENV: &str = "BW_CLIENTID";
 pub const BW_CLIENTSECRET_ENV: &str = "BW_CLIENTSECRET";
 pub const BW_PASSWORD_ENV: &str = "BW_PASSWORD";
 pub const BW_SESSION_ENV: &str = "BW_SESSION";
+
+/// Env var names we *read* credentials from, in priority order: the canonical
+/// `BW_*` name first, then the `BITWARDEN_*` alias many users prefer in a
+/// `.env`. The first non-empty match wins; whatever we read is handed to the
+/// `bw` subprocess under the canonical name above.
+pub const BW_CLIENTID_ENVS: &[&str] = &[BW_CLIENTID_ENV, "BITWARDEN_CLIENT_ID"];
+pub const BW_CLIENTSECRET_ENVS: &[&str] = &[BW_CLIENTSECRET_ENV, "BITWARDEN_CLIENT_SECRET"];
+pub const BW_PASSWORD_ENVS: &[&str] = &[
+    BW_PASSWORD_ENV,
+    "BITWARDEN_MASTER_PASSWORD",
+    "BITWARDEN_PASSWORD",
+];
+pub const BW_SESSION_ENVS: &[&str] = &[BW_SESSION_ENV, "BITWARDEN_SESSION"];
+
+/// First non-empty value among `names`. Treats an env var set to the empty
+/// string as unset so we never hand `bw` a blank password (which would make it
+/// fall back to an interactive prompt against a closed stdin).
+fn env_first(names: &[&str]) -> Option<String> {
+    names
+        .iter()
+        .find_map(|n| env::var(n).ok().filter(|v| !v.is_empty()))
+}
 
 /// Thin layer over the `bw` CLI. Exists so the field-extraction and error
 /// paths can be unit-tested without the binary on `$PATH`.
@@ -196,7 +221,7 @@ impl BitwardenSource<RealBwCli> {
         Self {
             config,
             cli: RealBwCli,
-            session_override: env::var(BW_SESSION_ENV).ok().filter(|s| !s.is_empty()),
+            session_override: env_first(BW_SESSION_ENVS),
         }
     }
 }
@@ -216,16 +241,23 @@ impl<C: BwCli> BitwardenSource<C> {
         }
         let status = self.cli.status().context("checking `bw status`")?;
         if status == BwStatus::Unauthenticated {
-            let client_id = env::var(BW_CLIENTID_ENV)
-                .map_err(|_| anyhow!("{BW_CLIENTID_ENV} must be set to log in to Bitwarden"))?;
-            let client_secret = env::var(BW_CLIENTSECRET_ENV)
-                .map_err(|_| anyhow!("{BW_CLIENTSECRET_ENV} must be set to log in to Bitwarden"))?;
+            let client_id = env_first(BW_CLIENTID_ENVS).ok_or_else(|| {
+                anyhow!("set {BW_CLIENTID_ENV} (or BITWARDEN_CLIENT_ID) to log in to Bitwarden")
+            })?;
+            let client_secret = env_first(BW_CLIENTSECRET_ENVS).ok_or_else(|| {
+                anyhow!(
+                    "set {BW_CLIENTSECRET_ENV} (or BITWARDEN_CLIENT_SECRET) to log in to Bitwarden"
+                )
+            })?;
             self.cli
                 .login_apikey(&client_id, &client_secret)
                 .context("`bw login --apikey` failed")?;
         }
-        let password = env::var(BW_PASSWORD_ENV)
-            .map_err(|_| anyhow!("{BW_PASSWORD_ENV} must be set to unlock the Bitwarden vault"))?;
+        let password = env_first(BW_PASSWORD_ENVS).ok_or_else(|| {
+            anyhow!(
+                "set {BW_PASSWORD_ENV} (or BITWARDEN_MASTER_PASSWORD) to unlock the Bitwarden vault"
+            )
+        })?;
         let session = self.cli.unlock(&password).context("`bw unlock` failed")?;
         self.cli.sync(&session).context("`bw sync` failed")?;
         Ok(session)
@@ -409,6 +441,58 @@ mod tests {
             calls,
             vec!["status", "login", "unlock", "sync", "get_item:stripe"]
         );
+    }
+
+    #[test]
+    fn env_first_prefers_canonical_then_alias_and_skips_empty() {
+        std::env::remove_var(BW_PASSWORD_ENV);
+        std::env::remove_var("BITWARDEN_MASTER_PASSWORD");
+        assert_eq!(env_first(BW_PASSWORD_ENVS), None);
+        std::env::set_var("BITWARDEN_MASTER_PASSWORD", "alias");
+        assert_eq!(env_first(BW_PASSWORD_ENVS).as_deref(), Some("alias"));
+        // An empty canonical var is treated as unset, so the alias still wins.
+        std::env::set_var(BW_PASSWORD_ENV, "");
+        assert_eq!(env_first(BW_PASSWORD_ENVS).as_deref(), Some("alias"));
+        // A non-empty canonical var takes priority over the alias.
+        std::env::set_var(BW_PASSWORD_ENV, "canonical");
+        assert_eq!(env_first(BW_PASSWORD_ENVS).as_deref(), Some("canonical"));
+        std::env::remove_var(BW_PASSWORD_ENV);
+        std::env::remove_var("BITWARDEN_MASTER_PASSWORD");
+    }
+
+    #[test]
+    fn bitwarden_source_accepts_bitwarden_prefixed_aliases() {
+        let mut items = HashMap::new();
+        items.insert("foo".to_string(), json!({"login": {"password": "v"}}));
+        let mock = MockBw {
+            status: BwStatus::Unauthenticated,
+            items,
+            calls: RefCell::new(Vec::new()),
+        };
+        // Only the BITWARDEN_* aliases are set; the native BW_* names are unset.
+        std::env::remove_var(BW_CLIENTID_ENV);
+        std::env::remove_var(BW_CLIENTSECRET_ENV);
+        std::env::remove_var(BW_PASSWORD_ENV);
+        std::env::remove_var(BW_SESSION_ENV);
+        std::env::set_var("BITWARDEN_CLIENT_ID", "id");
+        std::env::set_var("BITWARDEN_CLIENT_SECRET", "sec");
+        std::env::set_var("BITWARDEN_MASTER_PASSWORD", "pw");
+        let src = BitwardenSource::with_cli(BitwardenSourceConfig::default(), mock, None);
+        let secrets = vec![ManifestSecret {
+            name: "FOO".into(),
+            item: Some("foo".into()),
+            field: None,
+        }];
+        let got = src.fetch(&secrets).unwrap();
+        assert_eq!(got[0].value, "v");
+        let calls = src.cli.calls.borrow().clone();
+        assert_eq!(
+            calls,
+            vec!["status", "login", "unlock", "sync", "get_item:foo"]
+        );
+        std::env::remove_var("BITWARDEN_CLIENT_ID");
+        std::env::remove_var("BITWARDEN_CLIENT_SECRET");
+        std::env::remove_var("BITWARDEN_MASTER_PASSWORD");
     }
 
     #[test]

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -1,0 +1,439 @@
+//! Secret sources: where the manifest pulls values from.
+//!
+//! `SecretSource` is the single-method trait the orchestrator drives. The
+//! first concrete implementation is `BitwardenSource`, which shells out to
+//! the official `bw` CLI authenticated via the Bitwarden personal API key
+//! (`BW_CLIENTID` + `BW_CLIENTSECRET` + `BW_PASSWORD`).
+
+use std::collections::HashMap;
+use std::env;
+use std::process::{Command, Output};
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::manifest::{BitwardenSourceConfig, ManifestSecret};
+
+/// A plaintext value retrieved from a source. Callers MUST treat this as
+/// sensitive and must never log or persist `value` outside the documented
+/// destinations.
+#[derive(Debug, Clone)]
+pub struct FetchedSecret {
+    pub name: String,
+    pub value: String,
+}
+
+/// Anything that can hand the orchestrator the current values for a list of
+/// manifest secrets.
+pub trait SecretSource {
+    fn fetch(&self, secrets: &[ManifestSecret]) -> Result<Vec<FetchedSecret>>;
+}
+
+/// In-memory source used by tests and (eventually) by a `manifest dry-run`
+/// flow.
+#[derive(Debug, Default, Clone)]
+pub struct StaticSource {
+    pub values: HashMap<String, String>,
+}
+
+impl StaticSource {
+    pub fn new<I, K, V>(entries: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        Self {
+            values: entries
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
+        }
+    }
+}
+
+impl SecretSource for StaticSource {
+    fn fetch(&self, secrets: &[ManifestSecret]) -> Result<Vec<FetchedSecret>> {
+        let mut out = Vec::with_capacity(secrets.len());
+        for s in secrets {
+            let value = self
+                .values
+                .get(&s.name)
+                .ok_or_else(|| anyhow!("static source has no value for '{}'", s.name))?;
+            out.push(FetchedSecret {
+                name: s.name.clone(),
+                value: value.clone(),
+            });
+        }
+        Ok(out)
+    }
+}
+
+// ---- Bitwarden ----
+
+pub const BW_CLIENTID_ENV: &str = "BW_CLIENTID";
+pub const BW_CLIENTSECRET_ENV: &str = "BW_CLIENTSECRET";
+pub const BW_PASSWORD_ENV: &str = "BW_PASSWORD";
+pub const BW_SESSION_ENV: &str = "BW_SESSION";
+
+/// Thin layer over the `bw` CLI. Exists so the field-extraction and error
+/// paths can be unit-tested without the binary on `$PATH`.
+pub trait BwCli {
+    fn status(&self) -> Result<BwStatus>;
+    fn login_apikey(&self, client_id: &str, client_secret: &str) -> Result<()>;
+    fn unlock(&self, password: &str) -> Result<String>;
+    fn sync(&self, session: &str) -> Result<()>;
+    fn get_item(&self, session: &str, identifier: &str) -> Result<Value>;
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum BwStatus {
+    Unauthenticated,
+    Locked,
+    Unlocked,
+    #[serde(other)]
+    Other,
+}
+
+/// The production `bw` runner. Each call spawns the binary fresh, so a
+/// `bw` upgrade between calls doesn't strand a stale process.
+pub struct RealBwCli;
+
+impl RealBwCli {
+    fn run(args: &[&str], env: &[(&str, &str)]) -> Result<Output> {
+        let mut cmd = Command::new("bw");
+        cmd.args(args);
+        for (k, v) in env {
+            cmd.env(k, v);
+        }
+        cmd.output()
+            .with_context(|| format!("running `bw {}` (is the Bitwarden CLI installed?)", args[0]))
+    }
+
+    fn expect_success(args: &[&str], out: &Output) -> Result<()> {
+        if out.status.success() {
+            return Ok(());
+        }
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        // bw stderr never carries the secret value, so it's safe to surface.
+        bail!(
+            "`bw {}` failed with status {}: {}",
+            args[0],
+            out.status,
+            stderr.trim()
+        );
+    }
+}
+
+impl BwCli for RealBwCli {
+    fn status(&self) -> Result<BwStatus> {
+        let args = ["status"];
+        let out = Self::run(&args, &[])?;
+        Self::expect_success(&args, &out)?;
+        let parsed: Value = serde_json::from_slice(&out.stdout)
+            .context("parsing `bw status` JSON (unexpected format)")?;
+        match parsed.get("status").and_then(Value::as_str) {
+            Some("unauthenticated") => Ok(BwStatus::Unauthenticated),
+            Some("locked") => Ok(BwStatus::Locked),
+            Some("unlocked") => Ok(BwStatus::Unlocked),
+            _ => Ok(BwStatus::Other),
+        }
+    }
+
+    fn login_apikey(&self, client_id: &str, client_secret: &str) -> Result<()> {
+        let args = ["login", "--apikey"];
+        let out = Self::run(
+            &args,
+            &[
+                (BW_CLIENTID_ENV, client_id),
+                (BW_CLIENTSECRET_ENV, client_secret),
+            ],
+        )?;
+        Self::expect_success(&args, &out)
+    }
+
+    fn unlock(&self, password: &str) -> Result<String> {
+        let args = ["unlock", "--raw", "--passwordenv", BW_PASSWORD_ENV];
+        let out = Self::run(&args, &[(BW_PASSWORD_ENV, password)])?;
+        Self::expect_success(&args, &out)?;
+        let session = String::from_utf8(out.stdout)
+            .context("`bw unlock` did not return UTF-8")?
+            .trim()
+            .to_string();
+        if session.is_empty() {
+            bail!("`bw unlock` returned an empty session token");
+        }
+        Ok(session)
+    }
+
+    fn sync(&self, session: &str) -> Result<()> {
+        let args = ["sync"];
+        let out = Self::run(&args, &[(BW_SESSION_ENV, session)])?;
+        Self::expect_success(&args, &out)
+    }
+
+    fn get_item(&self, session: &str, identifier: &str) -> Result<Value> {
+        let args = ["get", "item", identifier];
+        let out = Self::run(&args, &[(BW_SESSION_ENV, session)])?;
+        Self::expect_success(&args, &out)?;
+        serde_json::from_slice(&out.stdout)
+            .with_context(|| format!("parsing `bw get item {identifier}` JSON"))
+    }
+}
+
+pub struct BitwardenSource<C: BwCli = RealBwCli> {
+    config: BitwardenSourceConfig,
+    cli: C,
+    /// If set, used instead of running login/unlock. Useful when the caller
+    /// already has an unlocked session.
+    session_override: Option<String>,
+}
+
+impl BitwardenSource<RealBwCli> {
+    pub fn new(config: BitwardenSourceConfig) -> Self {
+        Self {
+            config,
+            cli: RealBwCli,
+            session_override: env::var(BW_SESSION_ENV).ok().filter(|s| !s.is_empty()),
+        }
+    }
+}
+
+impl<C: BwCli> BitwardenSource<C> {
+    pub fn with_cli(config: BitwardenSourceConfig, cli: C, session: Option<String>) -> Self {
+        Self {
+            config,
+            cli,
+            session_override: session,
+        }
+    }
+
+    fn ensure_session(&self) -> Result<String> {
+        if let Some(s) = &self.session_override {
+            return Ok(s.clone());
+        }
+        let status = self.cli.status().context("checking `bw status`")?;
+        if status == BwStatus::Unauthenticated {
+            let client_id = env::var(BW_CLIENTID_ENV)
+                .map_err(|_| anyhow!("{BW_CLIENTID_ENV} must be set to log in to Bitwarden"))?;
+            let client_secret = env::var(BW_CLIENTSECRET_ENV)
+                .map_err(|_| anyhow!("{BW_CLIENTSECRET_ENV} must be set to log in to Bitwarden"))?;
+            self.cli
+                .login_apikey(&client_id, &client_secret)
+                .context("`bw login --apikey` failed")?;
+        }
+        let password = env::var(BW_PASSWORD_ENV)
+            .map_err(|_| anyhow!("{BW_PASSWORD_ENV} must be set to unlock the Bitwarden vault"))?;
+        let session = self.cli.unlock(&password).context("`bw unlock` failed")?;
+        self.cli.sync(&session).context("`bw sync` failed")?;
+        Ok(session)
+    }
+
+    fn default_field(&self) -> &str {
+        self.config.default_field.as_deref().unwrap_or("password")
+    }
+}
+
+impl<C: BwCli> SecretSource for BitwardenSource<C> {
+    fn fetch(&self, secrets: &[ManifestSecret]) -> Result<Vec<FetchedSecret>> {
+        if secrets.is_empty() {
+            return Ok(Vec::new());
+        }
+        let session = self.ensure_session()?;
+        let mut out = Vec::with_capacity(secrets.len());
+        for s in secrets {
+            let item_id = s.source_item();
+            let item = self
+                .cli
+                .get_item(&session, item_id)
+                .with_context(|| format!("fetching '{}' from Bitwarden", s.name))?;
+            let field = s.field.as_deref().unwrap_or_else(|| self.default_field());
+            let value = extract_field(&item, field).with_context(|| {
+                format!("extracting field '{field}' from Bitwarden item '{item_id}'")
+            })?;
+            out.push(FetchedSecret {
+                name: s.name.clone(),
+                value,
+            });
+        }
+        Ok(out)
+    }
+}
+
+/// Pulls a field out of a Bitwarden item's JSON.
+///
+/// Supported field specs:
+/// - `password` / `login.password`
+/// - `username` / `login.username`
+/// - `notes`
+/// - `fields.<NAME>` for custom fields
+pub fn extract_field(item: &Value, field: &str) -> Result<String> {
+    match field {
+        "password" | "login.password" => item
+            .pointer("/login/password")
+            .and_then(Value::as_str)
+            .map(String::from)
+            .ok_or_else(|| anyhow!("item has no login.password")),
+        "username" | "login.username" => item
+            .pointer("/login/username")
+            .and_then(Value::as_str)
+            .map(String::from)
+            .ok_or_else(|| anyhow!("item has no login.username")),
+        "notes" => item
+            .get("notes")
+            .and_then(Value::as_str)
+            .map(String::from)
+            .ok_or_else(|| anyhow!("item has no notes")),
+        other if other.starts_with("fields.") => {
+            let target = &other["fields.".len()..];
+            let arr = item
+                .get("fields")
+                .and_then(Value::as_array)
+                .ok_or_else(|| anyhow!("item has no custom fields"))?;
+            for f in arr {
+                if f.get("name").and_then(Value::as_str) == Some(target) {
+                    return f
+                        .get("value")
+                        .and_then(Value::as_str)
+                        .map(String::from)
+                        .ok_or_else(|| anyhow!("custom field '{target}' has no string value"));
+                }
+            }
+            Err(anyhow!("no custom field named '{target}'"))
+        }
+        other => Err(anyhow!("unsupported field selector '{other}'")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::cell::RefCell;
+
+    #[test]
+    fn extract_password_field() {
+        let item = json!({"login": {"password": "secret", "username": "alice"}});
+        assert_eq!(extract_field(&item, "password").unwrap(), "secret");
+        assert_eq!(extract_field(&item, "login.password").unwrap(), "secret");
+        assert_eq!(extract_field(&item, "username").unwrap(), "alice");
+    }
+
+    #[test]
+    fn extract_custom_field() {
+        let item = json!({
+            "fields": [
+                {"name": "API_URL", "value": "https://x", "type": 0},
+                {"name": "OTHER", "value": "y", "type": 1}
+            ]
+        });
+        assert_eq!(extract_field(&item, "fields.API_URL").unwrap(), "https://x");
+        assert!(extract_field(&item, "fields.MISSING").is_err());
+    }
+
+    #[test]
+    fn extract_notes() {
+        let item = json!({"notes": "abc"});
+        assert_eq!(extract_field(&item, "notes").unwrap(), "abc");
+    }
+
+    #[test]
+    fn extract_unsupported_field_is_an_error() {
+        let item = json!({});
+        assert!(extract_field(&item, "totp").is_err());
+    }
+
+    /// Mock CLI that tracks calls so we can assert the source did login/unlock
+    /// in the right order and used the session token for subsequent calls.
+    struct MockBw {
+        status: BwStatus,
+        items: HashMap<String, Value>,
+        calls: RefCell<Vec<String>>,
+    }
+
+    impl BwCli for MockBw {
+        fn status(&self) -> Result<BwStatus> {
+            self.calls.borrow_mut().push("status".into());
+            Ok(self.status.clone())
+        }
+        fn login_apikey(&self, _id: &str, _sec: &str) -> Result<()> {
+            self.calls.borrow_mut().push("login".into());
+            Ok(())
+        }
+        fn unlock(&self, _password: &str) -> Result<String> {
+            self.calls.borrow_mut().push("unlock".into());
+            Ok("MOCK_SESSION".into())
+        }
+        fn sync(&self, _session: &str) -> Result<()> {
+            self.calls.borrow_mut().push("sync".into());
+            Ok(())
+        }
+        fn get_item(&self, _session: &str, identifier: &str) -> Result<Value> {
+            self.calls
+                .borrow_mut()
+                .push(format!("get_item:{identifier}"));
+            self.items
+                .get(identifier)
+                .cloned()
+                .ok_or_else(|| anyhow!("no mock item '{identifier}'"))
+        }
+    }
+
+    #[test]
+    fn bitwarden_source_logs_in_then_fetches() {
+        let mut items = HashMap::new();
+        items.insert("stripe".to_string(), json!({"login": {"password": "sk"}}));
+        let mock = MockBw {
+            status: BwStatus::Unauthenticated,
+            items,
+            calls: RefCell::new(Vec::new()),
+        };
+        std::env::set_var(BW_CLIENTID_ENV, "id");
+        std::env::set_var(BW_CLIENTSECRET_ENV, "sec");
+        std::env::set_var(BW_PASSWORD_ENV, "pw");
+        std::env::remove_var(BW_SESSION_ENV);
+        let src = BitwardenSource::with_cli(BitwardenSourceConfig::default(), mock, None);
+        let secrets = vec![ManifestSecret {
+            name: "STRIPE".into(),
+            item: Some("stripe".into()),
+            field: None,
+        }];
+        let got = src.fetch(&secrets).unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].name, "STRIPE");
+        assert_eq!(got[0].value, "sk");
+        let calls = src.cli.calls.borrow().clone();
+        assert_eq!(
+            calls,
+            vec!["status", "login", "unlock", "sync", "get_item:stripe"]
+        );
+    }
+
+    #[test]
+    fn bitwarden_source_skips_login_when_session_override() {
+        let mut items = HashMap::new();
+        items.insert("foo".to_string(), json!({"login": {"password": "v"}}));
+        let mock = MockBw {
+            status: BwStatus::Unlocked,
+            items,
+            calls: RefCell::new(Vec::new()),
+        };
+        let src = BitwardenSource::with_cli(
+            BitwardenSourceConfig::default(),
+            mock,
+            Some("ABCDEF".into()),
+        );
+        let secrets = vec![ManifestSecret {
+            name: "FOO".into(),
+            item: Some("foo".into()),
+            field: None,
+        }];
+        let got = src.fetch(&secrets).unwrap();
+        assert_eq!(got[0].value, "v");
+        let calls = src.cli.calls.borrow().clone();
+        // No status/login/unlock/sync — straight to get_item.
+        assert_eq!(calls, vec!["get_item:foo"]);
+    }
+}

--- a/src/sync_manifest.rs
+++ b/src/sync_manifest.rs
@@ -1,0 +1,235 @@
+//! Manifest-driven sync orchestrator: pull all managed secrets from the
+//! configured source, push to every destination that's missing the current
+//! value, and persist per-destination hashes for next time.
+
+use std::collections::HashMap;
+use std::env;
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+use crate::destinations::{
+    Destination, DestinationEntry, DestinationReport, DestinationRequest, EnvFileDestination,
+    GitHubDestination,
+};
+use crate::manifest::{
+    value_hash, ManifestDestination, ManifestSource, RepoManifest, SyncState, DEFAULT_STATE_FILE,
+};
+use crate::sources::{BitwardenSource, SecretSource, StaticSource};
+
+/// Test-only override: if set, points at a JSON file `{ "NAME": "value", ... }`
+/// that is used as a static source in place of the manifest's configured one.
+/// Lets the wiremock e2e suite drive the binary without contacting Bitwarden.
+/// Intentionally undocumented in `--help`, mirroring `GH_SECRETS_API_BASE`.
+pub const TEST_SOURCE_FILE_ENV: &str = "GH_SECRETS_TEST_SOURCE_FILE";
+
+#[derive(Debug, Default)]
+pub struct ManifestSyncReport {
+    pub destinations: Vec<DestinationOutcome>,
+}
+
+#[derive(Debug)]
+pub struct DestinationOutcome {
+    pub destination_key: String,
+    pub report: DestinationReport,
+}
+
+impl ManifestSyncReport {
+    pub fn is_noop(&self) -> bool {
+        self.destinations.iter().all(|d| !d.report.changed())
+    }
+}
+
+/// Top-level entry: load manifest + state, pull from source, push to all
+/// destinations, write state. `manifest_path` and `state_path` are absolute or
+/// relative to the caller's CWD.
+pub fn sync_manifest(
+    manifest_path: &Path,
+    state_path: Option<&Path>,
+) -> Result<ManifestSyncReport> {
+    let manifest = RepoManifest::load(manifest_path)
+        .with_context(|| format!("loading manifest from {}", manifest_path.display()))?;
+    let state_path = match state_path {
+        Some(p) => p.to_path_buf(),
+        None => default_state_path(manifest_path),
+    };
+    let mut state = SyncState::load_or_default(&state_path)?;
+    let source = resolve_source(&manifest.source)?;
+    let report = run(&manifest, &mut state, source.as_ref(), manifest_path)?;
+    state.save(&state_path)?;
+    Ok(report)
+}
+
+fn resolve_source(source: &ManifestSource) -> Result<Box<dyn SecretSource>> {
+    if let Ok(path) = env::var(TEST_SOURCE_FILE_ENV) {
+        let bytes = fs::read(&path).with_context(|| format!("reading test source file {path}"))?;
+        let values: HashMap<String, String> = serde_json::from_slice(&bytes)
+            .with_context(|| format!("parsing test source file {path} as JSON"))?;
+        return Ok(Box::new(StaticSource { values }));
+    }
+    match source {
+        ManifestSource::Bitwarden(cfg) => Ok(Box::new(BitwardenSource::new(cfg.clone()))),
+    }
+}
+
+/// Same as `sync_manifest` but takes a pre-built source — used by tests with a
+/// `StaticSource`.
+pub fn sync_manifest_with_source(
+    manifest_path: &Path,
+    state_path: Option<&Path>,
+    source: &dyn SecretSource,
+) -> Result<ManifestSyncReport> {
+    let manifest = RepoManifest::load(manifest_path)
+        .with_context(|| format!("loading manifest from {}", manifest_path.display()))?;
+    let state_path = match state_path {
+        Some(p) => p.to_path_buf(),
+        None => default_state_path(manifest_path),
+    };
+    let mut state = SyncState::load_or_default(&state_path)?;
+    let report = run(&manifest, &mut state, source, manifest_path)?;
+    state.save(&state_path)?;
+    Ok(report)
+}
+
+fn run(
+    manifest: &RepoManifest,
+    state: &mut SyncState,
+    source: &dyn SecretSource,
+    manifest_path: &Path,
+) -> Result<ManifestSyncReport> {
+    let base_dir = manifest_path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+
+    let fetched = source
+        .fetch(&manifest.secrets)
+        .context("fetching from source")?;
+
+    // Compute current hashes once.
+    let mut entries: Vec<DestinationEntry> = Vec::with_capacity(fetched.len());
+    for f in &fetched {
+        let h = value_hash(&f.name, &f.value);
+        state.record_source(&f.name, &h);
+        entries.push(DestinationEntry {
+            name: f.name.clone(),
+            value: f.value.clone(),
+            current_hash: h,
+            last_pushed_hash: None, // filled in per-destination below
+        });
+    }
+
+    let mut report = ManifestSyncReport::default();
+    for dest_cfg in &manifest.destinations {
+        let mut destination: Box<dyn Destination> = match dest_cfg {
+            ManifestDestination::Github(c) => Box::new(GitHubDestination::from_config(c)?),
+            ManifestDestination::EnvFile(c) => {
+                Box::new(EnvFileDestination::from_config(c, base_dir))
+            }
+        };
+        let dest_key = destination.key();
+        // Per-destination request: inject the last-pushed hash from state.
+        let mut req = DestinationRequest::default();
+        for entry in &entries {
+            let last = state
+                .last_pushed_hash(&entry.name, &dest_key)
+                .map(String::from);
+            req.entries.push(DestinationEntry {
+                name: entry.name.clone(),
+                value: entry.value.clone(),
+                current_hash: entry.current_hash.clone(),
+                last_pushed_hash: last,
+            });
+        }
+        let dest_report = destination
+            .apply(req)
+            .with_context(|| format!("applying to destination {dest_key}"))?;
+        for name in dest_report.created.iter().chain(dest_report.updated.iter()) {
+            // Find the hash we just pushed.
+            if let Some(entry) = entries.iter().find(|e| &e.name == name) {
+                state.record_push(name, &dest_key, &entry.current_hash);
+            }
+        }
+        // For unchanged destinations whose state was missing (e.g. first run
+        // against a file that already had the value), still record so we
+        // converge on the no-op next time.
+        for name in &dest_report.unchanged {
+            if let Some(entry) = entries.iter().find(|e| &e.name == name) {
+                state.record_push(name, &dest_key, &entry.current_hash);
+            }
+        }
+        report.destinations.push(DestinationOutcome {
+            destination_key: dest_key,
+            report: dest_report,
+        });
+    }
+    Ok(report)
+}
+
+fn default_state_path(manifest_path: &Path) -> std::path::PathBuf {
+    manifest_path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+        .join(DEFAULT_STATE_FILE)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manifest::{BitwardenSourceConfig, EnvFileDestinationConfig, ManifestSecret};
+    use crate::sources::StaticSource;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn manifest_with_env_file(dir: &Path, env_path: PathBuf) -> PathBuf {
+        let manifest = RepoManifest {
+            source: ManifestSource::Bitwarden(BitwardenSourceConfig::default()),
+            secrets: vec![ManifestSecret {
+                name: "FOO".into(),
+                item: None,
+                field: None,
+            }],
+            destinations: vec![ManifestDestination::EnvFile(EnvFileDestinationConfig {
+                path: env_path,
+            })],
+        };
+        let manifest_path = dir.join("gh-secrets.json");
+        manifest.save(&manifest_path).unwrap();
+        manifest_path
+    }
+
+    #[test]
+    fn end_to_end_env_file_round_trip() {
+        let dir = TempDir::new().unwrap();
+        let env_path = PathBuf::from(".env");
+        let manifest_path = manifest_with_env_file(dir.path(), env_path);
+        let source = StaticSource::new(vec![("FOO", "bar")]);
+        let report = sync_manifest_with_source(&manifest_path, None, &source).unwrap();
+        assert_eq!(report.destinations.len(), 1);
+        assert_eq!(report.destinations[0].report.created, vec!["FOO"]);
+
+        let env_path_abs = dir.path().join(".env");
+        let content = std::fs::read_to_string(&env_path_abs).unwrap();
+        assert_eq!(content, "FOO=\"bar\"\n");
+
+        // Re-running with same source value should be a no-op.
+        let report2 = sync_manifest_with_source(&manifest_path, None, &source).unwrap();
+        assert!(report2.is_noop());
+        assert_eq!(report2.destinations[0].report.unchanged, vec!["FOO"]);
+    }
+
+    #[test]
+    fn source_change_propagates_to_env_file() {
+        let dir = TempDir::new().unwrap();
+        let manifest_path = manifest_with_env_file(dir.path(), PathBuf::from(".env"));
+        let source = StaticSource::new(vec![("FOO", "v1")]);
+        let _ = sync_manifest_with_source(&manifest_path, None, &source).unwrap();
+        let source2 = StaticSource::new(vec![("FOO", "v2")]);
+        let report = sync_manifest_with_source(&manifest_path, None, &source2).unwrap();
+        assert_eq!(report.destinations[0].report.updated, vec!["FOO"]);
+        let content = std::fs::read_to_string(dir.path().join(".env")).unwrap();
+        assert!(content.contains("FOO=\"v2\""));
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,6 +1,8 @@
 // Shared helpers for the e2e tests. `mod common` in a sibling integration test
 // file (`tests/e2e.rs`) pulls these in; the `mod.rs` form keeps cargo from
-// building this file as a stand-alone test binary.
+// building this file as a stand-alone test binary. Not every consumer uses
+// every item — silence `dead_code` so partial use doesn't produce warnings.
+#![allow(dead_code)]
 
 use assert_cmd::Command;
 use base64::engine::general_purpose::STANDARD as B64;

--- a/tests/e2e_manifest.rs
+++ b/tests/e2e_manifest.rs
@@ -1,0 +1,258 @@
+//! End-to-end tests for the manifest-driven sync flow.
+//!
+//! Drives the compiled `gh-secrets` binary the way a user does, against a
+//! mocked GitHub API + a JSON-file "static" source (via
+//! `GH_SECRETS_TEST_SOURCE_FILE`). This exercises the orchestrator, source
+//! abstraction, env-file destination, and GitHub destination together — same
+//! plumbing the user hits when running `gh-secrets manifest sync` in their
+//! repo, minus only the Bitwarden CLI call (which is covered by unit tests
+//! against a mock `BwCli`).
+//!
+//! What's covered:
+//! - `manifest init` writes a usable starter manifest.
+//! - `manifest sync` pushes to both GitHub (one PUT per secret) and the local
+//!   env file simultaneously.
+//! - The env file ends up with the expected content and preserves unrelated
+//!   lines that were already there.
+//! - A second `manifest sync` against the same source values is a no-op (no
+//!   GitHub PUT, no env file change).
+//! - Changing the source value causes a new GitHub PUT and an env-file update.
+//! - The PUT body is structurally a sealed-box: base64 of 32 (ephemeral
+//!   pubkey) + 16 (MAC) + ciphertext bytes — and the plaintext never appears
+//!   in the body. Same guard as `e2e.rs` has for the profile-based sync.
+
+mod common;
+
+use std::fs;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use assert_cmd::Command;
+use base64::engine::general_purpose::STANDARD as B64;
+use base64::Engine;
+use common::fake_pubkey_b64;
+use predicates::str::contains;
+use serde_json::{json, Value};
+use tempfile::TempDir;
+use wiremock::matchers::{header, method, path_regex};
+use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+
+/// Per-test harness: tempdir for working files (manifest, state, source JSON,
+/// env destination), wiremock for GitHub, captured PUT bodies for assertions.
+struct ManifestHarness {
+    dir: TempDir,
+    server: MockServer,
+    put_bodies: Arc<Mutex<Vec<(String, Value)>>>, // (secret name, JSON body)
+}
+
+impl ManifestHarness {
+    async fn new() -> Self {
+        let dir = TempDir::new().expect("tempdir");
+        let server = MockServer::start().await;
+        Self {
+            dir,
+            server,
+            put_bodies: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn write_manifest(&self, manifest: &Value) {
+        let path = self.dir.path().join("gh-secrets.json");
+        fs::write(&path, serde_json::to_vec_pretty(manifest).unwrap()).unwrap();
+    }
+
+    fn write_source(&self, values: &Value) {
+        let path = self.dir.path().join("source.json");
+        fs::write(&path, serde_json::to_vec_pretty(values).unwrap()).unwrap();
+    }
+
+    fn cmd(&self) -> Command {
+        let mut c = Command::cargo_bin("gh-secrets").expect("locate gh-secrets bin");
+        c.current_dir(self.dir.path())
+            .env(
+                "GH_SECRETS_HOME",
+                self.dir.path().join("home"), // separate from manifest dir
+            )
+            .env("GH_SECRETS_API_BASE", self.server.uri())
+            .env(
+                "GH_SECRETS_TEST_SOURCE_FILE",
+                self.dir.path().join("source.json"),
+            )
+            .env("GH_TOKEN", "ghp_test");
+        c
+    }
+
+    fn env_file(&self) -> std::path::PathBuf {
+        self.dir.path().join(".env")
+    }
+
+    fn state_file(&self) -> std::path::PathBuf {
+        self.dir.path().join(".gh-secrets-state.json")
+    }
+
+    async fn mount_github(&self, repo: &str) {
+        let path_re = format!("^/repos/{repo}/actions/secrets/public-key$");
+        Mock::given(method("GET"))
+            .and(path_regex(path_re))
+            .and(header("authorization", "Bearer ghp_test"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "key_id": "kid-1",
+                "key": fake_pubkey_b64(),
+            })))
+            .mount(&self.server)
+            .await;
+
+        let bodies = self.put_bodies.clone();
+        let path_re = format!("^/repos/{repo}/actions/secrets/(.+)$");
+        Mock::given(method("PUT"))
+            .and(path_regex(path_re))
+            .and(header("authorization", "Bearer ghp_test"))
+            .respond_with(move |req: &Request| {
+                let name = req.url.path().rsplit('/').next().unwrap_or("").to_string();
+                let body: Value = serde_json::from_slice(&req.body).expect("PUT body is JSON");
+                bodies.lock().unwrap().push((name, body));
+                ResponseTemplate::new(201)
+            })
+            .mount(&self.server)
+            .await;
+    }
+}
+
+fn manifest_for(repo: &str) -> Value {
+    json!({
+        "source": {"type": "bitwarden"},
+        "secrets": [
+            {"name": "FOO"},
+            {"name": "BAR"}
+        ],
+        "destinations": [
+            {"type": "github", "repository": repo},
+            {"type": "env_file", "path": ".env"}
+        ]
+    })
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_manifest_init_writes_starter() {
+    let h = ManifestHarness::new().await;
+    h.cmd()
+        .args(["manifest", "init"])
+        .assert()
+        .success()
+        .stdout(contains("wrote starter"));
+    let path = h.dir.path().join("gh-secrets.json");
+    let body: Value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+    assert_eq!(body["source"]["type"], "bitwarden");
+    assert!(!body["secrets"].as_array().unwrap().is_empty());
+    assert!(!body["destinations"].as_array().unwrap().is_empty());
+    // Re-running must refuse to overwrite a non-empty file.
+    h.cmd()
+        .args(["manifest", "init"])
+        .assert()
+        .failure()
+        .stderr(contains("refusing to overwrite"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_manifest_sync_pushes_to_github_and_env_file() {
+    let h = ManifestHarness::new().await;
+    let repo = "owner/repo1";
+    h.write_manifest(&manifest_for(repo));
+    h.write_source(&json!({"FOO": "foo-value", "BAR": "bar-value"}));
+    h.mount_github(repo).await;
+    // Pre-existing line that must survive.
+    fs::write(h.env_file(), "PRE_EXISTING=keepme\n").unwrap();
+
+    h.cmd()
+        .args(["manifest", "sync"])
+        .assert()
+        .success()
+        .stdout(contains("created"));
+
+    // GitHub: one PUT per secret, payload is sealed-box shaped, plaintext is
+    // not present anywhere in the request body.
+    let bodies = h.put_bodies.lock().unwrap();
+    assert_eq!(bodies.len(), 2);
+    for (name, body) in bodies.iter() {
+        assert_eq!(body["key_id"].as_str(), Some("kid-1"));
+        let ct_b64 = body["encrypted_value"]
+            .as_str()
+            .expect("encrypted_value present");
+        let raw = B64.decode(ct_b64).expect("encrypted_value is base64");
+        // Sealed box: 32-byte ephemeral pubkey + 16-byte MAC + ciphertext.
+        assert!(raw.len() > 32 + 16, "{name}: sealed box too short");
+        let serialized = serde_json::to_string(body).unwrap();
+        assert!(
+            !serialized.contains("foo-value") && !serialized.contains("bar-value"),
+            "plaintext leaked into PUT body for {name}"
+        );
+    }
+    drop(bodies);
+
+    // Env file: managed keys present + pre-existing line preserved.
+    let content = fs::read_to_string(h.env_file()).unwrap();
+    assert!(content.contains("PRE_EXISTING=keepme"));
+    assert!(content.contains("FOO=\"foo-value\""));
+    assert!(content.contains("BAR=\"bar-value\""));
+
+    // State file written, references both destinations.
+    let state: Value = serde_json::from_slice(&fs::read(h.state_file()).unwrap()).unwrap();
+    let foo_dests = &state["secrets"]["FOO"]["destinations"];
+    assert!(foo_dests[format!("github:{repo}")].is_string());
+    assert!(foo_dests["env_file:.env"].is_string());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_manifest_resync_with_unchanged_source_is_a_noop() {
+    let h = ManifestHarness::new().await;
+    let repo = "owner/repo1";
+    h.write_manifest(&manifest_for(repo));
+    h.write_source(&json!({"FOO": "v1", "BAR": "v2"}));
+    h.mount_github(repo).await;
+
+    h.cmd().args(["manifest", "sync"]).assert().success();
+    assert_eq!(h.put_bodies.lock().unwrap().len(), 2);
+
+    // Second run, same values: should not PUT anything new.
+    h.cmd()
+        .args(["manifest", "sync"])
+        .assert()
+        .success()
+        .stdout(contains("nothing to do"));
+    assert_eq!(
+        h.put_bodies.lock().unwrap().len(),
+        2,
+        "no new PUTs on the no-op resync"
+    );
+
+    // Env file unchanged on disk.
+    let content = fs::read_to_string(h.env_file()).unwrap();
+    assert!(content.contains("FOO=\"v1\""));
+    assert!(content.contains("BAR=\"v2\""));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_manifest_source_change_repushes_only_that_secret() {
+    let h = ManifestHarness::new().await;
+    let repo = "owner/repo1";
+    h.write_manifest(&manifest_for(repo));
+    h.write_source(&json!({"FOO": "v1", "BAR": "v2"}));
+    h.mount_github(repo).await;
+
+    h.cmd().args(["manifest", "sync"]).assert().success();
+    assert_eq!(h.put_bodies.lock().unwrap().len(), 2);
+
+    // Update only FOO.
+    h.write_source(&json!({"FOO": "v1-updated", "BAR": "v2"}));
+    h.cmd().args(["manifest", "sync"]).assert().success();
+
+    // Expect exactly one additional PUT — for FOO.
+    let bodies = h.put_bodies.lock().unwrap();
+    assert_eq!(bodies.len(), 3);
+    assert_eq!(bodies.last().unwrap().0, "FOO");
+
+    // Env file shows the new value for FOO.
+    let content = fs::read_to_string(h.env_file()).unwrap();
+    assert!(content.contains("FOO=\"v1-updated\""));
+    assert!(content.contains("BAR=\"v2\""));
+}


### PR DESCRIPTION
## Why

Today `gh-secrets` only manages secrets the user types in locally. This PR adds a second, complementary workflow: secrets live in an **external store** (Bitwarden), the user checks in a **declarative manifest** describing which secrets to manage and where they should land, and `gh-secrets manifest sync` keeps every destination in lock-step with the source. Both old (profile-based) and new (manifest-based) workflows coexist; no breaking changes.

## Goals

1. **First external secret store: Bitwarden.** Source of truth lives in the user's vault; CI/local invocations pull current values via the `bw` CLI authenticated with the personal API key (`BW_CLIENTID` + `BW_CLIENTSECRET` + `BW_PASSWORD`). Architecture is provider-agnostic so a second source (e.g. 1Password, AWS Secrets Manager) drops in as another `SecretSource` impl.
2. **First non-GitHub destination: local `.env` file.** One config file, two sync targets — GitHub Actions repo secrets and a dotenv file — kept in sync simultaneously. Architecture is provider-agnostic so additional destinations (e.g. Vercel, Doppler) drop in as another `Destination` impl.
3. **Idempotent and quiet.** A re-run with unchanged source values is a true no-op: zero GitHub PUTs, zero env-file writes, one line of output (\`manifest sync: nothing to do\`). A change to a single source value repushes only that one secret to each destination.
4. **No plaintext ever persisted by the tool.** State is stored only as SHA-256 hashes (\`name + NUL + value\`, domain-separated). The on-disk state file, log lines, and error messages never contain a secret value.
5. **Default gate stays credential-free.** The wiremock e2e suite drives the full sync end-to-end without a real Bitwarden vault, using a documented test-only override that mirrors the existing \`GH_SECRETS_API_BASE\` pattern.

## What landed

### Code
- **\`src/manifest.rs\`** — typed manifest (\`source\` + \`secrets[]\` + \`destinations[]\`) and the co-located \`.gh-secrets-state.json\` (gitignore it) keyed \`secret_name → destination_key → SHA-256 of last pushed value\`. Atomic writes.
- **\`src/sources.rs\`** — \`SecretSource\` trait. Implementations:
  - \`StaticSource\` — in-memory, used by tests and the test-mode override.
  - \`BitwardenSource\` — shells out to \`bw\` via a small internal \`BwCli\` indirection so field extraction and the login/unlock/sync/get_item sequencing are unit-tested without the binary. Honors a pre-existing \`BW_SESSION\` when present, otherwise does \`login --apikey\` → \`unlock --raw --passwordenv BW_PASSWORD\` → \`sync\`. Field selectors: \`password\`, \`username\`, \`notes\`, \`fields.<NAME>\`.
- **\`src/destinations.rs\`** — \`Destination\` trait. Implementations:
  - \`GitHubDestination\` — wraps the existing client; lazily fetches the repo public key only once it has something to push; reads its token from \`GH_TOKEN\` / \`GITHUB_TOKEN\` (no per-manifest token field by design — the manifest is checked in, the token is not).
  - \`EnvFileDestination\` — preserves comments and unrelated lines; updates existing keys in place; appends new ones; double-quoted form with backslash escapes for \`\\\`, \`\"\`, \`\$\`, backtick, \`\\n\`/\`\\r\`/\`\\t\`; chmods to \`0600\` on Unix.
- **\`src/sync_manifest.rs\`** — orchestrator. Pulls all values, computes hashes once, builds a per-destination request with each entry's prior-push hash, applies, records new hashes only for created/updated. Includes \`GH_SECRETS_TEST_SOURCE_FILE\` (test-only, undocumented in \`--help\`) used by the wiremock e2e suite.
- **\`src/cli.rs\`** — \`manifest init\` (writes a starter \`gh-secrets.json\`, refuses to overwrite) and \`manifest sync\` (\`--config\`, \`--state\`). Independent of the existing profile commands.

### Tests
- **+47 tests, all green.** 26 unit + 21 e2e.
- **Unit:** manifest round-trip, state round-trip, value-hash domain separation, destination-key uniqueness; env-file parse/escape/preserve/state-driven-skip/tamper-rewrite; Bitwarden field extraction across all selectors; full Bitwarden login→unlock→sync→get_item call sequence against a mock \`BwCli\`.
- **E2E (\`tests/e2e_manifest.rs\`)** — 4 tests driving the compiled binary against wiremock + a JSON-file source:
  1. \`manifest init\` writes a usable starter and refuses to overwrite.
  2. A first sync pushes to GitHub and \`.env\` simultaneously; PUT body is sealed-box shaped (32 + 16 + ciphertext bytes); plaintext never appears in the request body; pre-existing env-file lines are preserved.
  3. A no-op re-sync issues **zero** additional GitHub PUTs and **zero** env-file writes.
  4. Changing one source value repushes **exactly one** secret.

### Plumbing
- \`Cargo.toml\` — add \`sha2\` (used only for the local hash state).
- \`justfile\` — add the new e2e binary to \`just test-e2e\` (still the default gate).
- \`AGENTS.md\` — full description of the new workflow, env-var contract, state-file invariant, and a 'tests are context engineering' addition documenting the new suite.

## Architecture at a glance

\`\`\`
        gh-secrets.json (checked in)
                │
                ▼
   ┌─────────────────────────┐
   │ ManifestSource (trait)  │ ◀── Bitwarden (today),
   └─────────────────────────┘     room for 1Password / AWS / etc.
                │ fetch()
                ▼
   ┌─────────────────────────┐
   │   Orchestrator          │ ◀── per-secret SHA-256 vs
   │   sync_manifest::run    │     .gh-secrets-state.json
   └─────────────────────────┘
        │           │
        ▼           ▼
  ┌──────────┐ ┌─────────────┐
  │ GitHub   │ │ EnvFile     │ ◀── room for Vercel / Doppler / etc.
  │ secrets  │ │ (.env)      │
  └──────────┘ └─────────────┘
\`\`\`

## Security invariants (preserved + extended)

- The CLI still never prints a secret value to stdout, stderr, log lines, or error messages — including the new flow. Verified by the e2e suite scanning every recorded PUT body for the known plaintext.
- The new state file stores only SHA-256(\`name + NUL + value\`). One-way, domain-separated. No plaintext persisted.
- The Bitwarden source passes \`BW_PASSWORD\` and \`BW_SESSION\` via env (never argv), avoiding ps-leakage.
- The GitHub destination reuses the existing libsodium-compatible sealed-box implementation; e2e tests assert the ciphertext shape and the absence of plaintext on the wire.

## What's remaining (optional follow-ups, not blocking)

1. **\`manifest init\` should also \`.gitignore\` the state file** — current behavior just writes the manifest; the user has to remember. \`init\` could append \`.gh-secrets-state.json\` to the local \`.gitignore\` (idempotently) so an accidental commit is impossible.
2. **\`manifest sync --dry-run\`** — print intended changes without contacting GitHub or writing the env file. Easy wrapper over \`apply\`.
3. **\`manifest check\`** — analogous to the existing \`check\` for the profile flow: report drift without pushing.
4. **Live Bitwarden e2e** — opt-in suite mirroring \`tests/e2e_live.rs\` for GitHub, exercising the real \`bw\` CLI against a sandbox vault. Gated by env vars, skipped by default. Useful once a CI \`BW_*\` secret is provisioned.
5. **Document or auto-install \`bw\`** — currently the user must have it on \`\$PATH\`. Either document the install steps in AGENTS.md or add a \`just bootstrap-bw\` recipe.
6. **Add \`.claude/scheduled_tasks.lock\` to \`.gitignore\`** — surfaced again during this work but intentionally not scope-creeped into this PR.

## Test plan
- [x] \`just check\` — full gate (fmt, clippy \`-D warnings\`, unit, e2e). 47 tests, all green locally.
- [ ] CI confirms the same on Linux + macOS + Windows.
- [ ] (Manual, post-merge) Drop a starter \`gh-secrets.json\` into a real repo, set \`BW_*\` and \`GH_TOKEN\`, run \`gh-secrets manifest sync\`, observe the secret appear in the GitHub repo and the local \`.env\`, run again, observe \`nothing to do\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)