### PR TITLE
Add cross-platform install script with checksum verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,6 +174,17 @@ For the manifest-driven flow:
   ```
   Without the secret, the `live-e2e` job in `.github/workflows/ci.yml` is a
   no-op. Rotate the PAT through the same command whenever needed.
+- `scripts/install.sh` is the cross-platform installer (Linux/macOS x86_64 +
+  arm64, Windows x86_64 under a POSIX shell): it detects the host target,
+  downloads the matching release archive, verifies its SHA-256, and installs
+  the binary. It must stay in lock-step with the release asset naming in
+  `release.yml` — the archive is `gh-secrets-<tag>-<target>.<ext>` and the
+  checksum asset is that name with `.sha256` *appended* (it keeps the
+  `.tar.gz`/`.zip`), and the binary sits under a leading
+  `gh-secrets-<tag>-<target>/` directory inside the archive. The live e2e
+  suite (`live_install_script_downloads_and_verifies_release`) runs the script
+  against the real release every CI run that has `GH_E2E_TOKEN`, so a drift in
+  asset naming fails the gate rather than only surfacing for a user.
 
 ## Keeping the allowlist current
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,27 @@ that have changed since the last sync.
 
 ## Install
 
-From a clone:
+Download the latest prebuilt binary, verify its SHA-256 checksum, and drop it
+on your PATH (Linux/macOS, and Windows under Git Bash / MSYS / WSL):
 
 ```sh
-cargo install --path .
+curl -fsSL https://raw.githubusercontent.com/nickderobertis/github-secrets/master/scripts/install.sh | sh
+```
+
+Pin a version or pick the install directory:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/nickderobertis/github-secrets/master/scripts/install.sh \
+  | sh -s -- --version v0.1.0 --to ~/.local/bin
+```
+
+The script defaults to `~/.local/bin`; set `GITHUB_TOKEN` to avoid the GitHub
+API rate limit when resolving the latest release. For native Windows PowerShell,
+or from a clone:
+
+```sh
+cargo install gh-secrets --locked   # from crates.io
+cargo install --path .              # from a clone
 ```
 
 ## Usage

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,233 @@
+#!/bin/sh
+# gh-secrets installer.
+#
+# Detect the host platform, download the matching prebuilt binary from the
+# GitHub release, verify its SHA-256 checksum, and install it onto your PATH.
+#
+# Install the latest release:
+#   curl -fsSL https://raw.githubusercontent.com/nickderobertis/github-secrets/master/scripts/install.sh | sh
+#
+# Pin a version or choose where it lands (flags win over the env vars):
+#   curl -fsSL .../install.sh | sh -s -- --version v0.1.0 --to ~/.local/bin
+#
+# Equivalent environment variables: GH_SECRETS_VERSION, GH_SECRETS_INSTALL_DIR.
+# Set GITHUB_TOKEN to lift the GitHub API rate limit when resolving "latest".
+#
+# Covers Linux and macOS (x86_64, arm64) and Windows x86_64 under a POSIX shell
+# (Git Bash / MSYS / WSL). For native Windows PowerShell or unpublished targets,
+# use `cargo install gh-secrets --locked`.
+#
+# Like the tool it installs, this script never weakens silently: it aborts
+# rather than install a binary it cannot checksum-verify.
+
+set -eu
+
+REPO="nickderobertis/github-secrets"
+BIN="gh-secrets"
+# Overridden to `gh-secrets.exe` on Windows targets by detect_target.
+BIN_FILE="$BIN"
+
+say() { printf '%s\n' "$*" >&2; }
+err() { printf 'error: %s\n' "$*" >&2; exit 1; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+usage() {
+    cat >&2 <<EOF
+Install the prebuilt gh-secrets binary.
+
+Usage: install.sh [--version <tag>] [--to <dir>]
+
+  --version <tag>   Release tag to install, e.g. v0.1.0 (default: latest).
+  --to <dir>        Install directory (default: ~/.local/bin).
+  -h, --help        Show this help.
+
+Environment: GH_SECRETS_VERSION, GH_SECRETS_INSTALL_DIR, GITHUB_TOKEN.
+EOF
+}
+
+# Map `uname` output to a published Rust target triple, archive extension, and
+# (on Windows) the `.exe` binary name. Unsupported pairs abort with guidance.
+detect_target() {
+    os="$(uname -s)"
+    arch="$(uname -m)"
+
+    case "$os" in
+        Linux) os_part="unknown-linux-gnu"; ext="tar.gz" ;;
+        Darwin) os_part="apple-darwin"; ext="tar.gz" ;;
+        MINGW* | MSYS* | CYGWIN* | Windows_NT)
+            os_part="pc-windows-msvc"; ext="zip"; BIN_FILE="${BIN}.exe" ;;
+        *) err "unsupported operating system: $os" ;;
+    esac
+
+    case "$arch" in
+        x86_64 | amd64) arch_part="x86_64" ;;
+        arm64 | aarch64) arch_part="aarch64" ;;
+        *) err "unsupported architecture: $arch" ;;
+    esac
+
+    # The release matrix publishes Windows for x86_64 only.
+    if [ "$ext" = "zip" ] && [ "$arch_part" != "x86_64" ]; then
+        err "no prebuilt Windows binary for $arch; install with 'cargo install $BIN --locked'"
+    fi
+
+    TARGET="${arch_part}-${os_part}"
+    EXT="$ext"
+}
+
+# Fetch a URL to stdout. Used only for the GitHub API call, so it carries the
+# optional token; release-asset downloads stay tokenless to avoid sending an
+# Authorization header to the redirected (signed) asset URL.
+api_get() {
+    _url="$1"
+    if [ "$DL" = "curl" ]; then
+        if [ -n "${GITHUB_TOKEN:-}" ]; then
+            curl -fsSL -H "Authorization: Bearer $GITHUB_TOKEN" "$_url"
+        else
+            curl -fsSL "$_url"
+        fi
+    else
+        if [ -n "${GITHUB_TOKEN:-}" ]; then
+            wget --header="Authorization: Bearer $GITHUB_TOKEN" -qO- "$_url"
+        else
+            wget -qO- "$_url"
+        fi
+    fi
+}
+
+# Download a release asset (follows redirects) to a file.
+download() {
+    _url="$1"
+    _out="$2"
+    if [ "$DL" = "curl" ]; then
+        curl -fsSL -o "$_out" "$_url"
+    else
+        wget -qO "$_out" "$_url"
+    fi
+}
+
+# Resolve the latest release tag by reading "tag_name" from the GitHub API.
+latest_tag() {
+    _body="$(api_get "https://api.github.com/repos/$REPO/releases/latest")" \
+        || err "could not query the latest release (set GITHUB_TOKEN if rate-limited)"
+    _tag="$(printf '%s\n' "$_body" \
+        | grep -m1 '"tag_name"' \
+        | sed -E 's/.*"tag_name":[[:space:]]*"([^"]+)".*/\1/')"
+    [ -n "$_tag" ] || err "could not parse the latest release tag from the GitHub API"
+    printf '%s\n' "$_tag"
+}
+
+# Print the SHA-256 of a file using whichever tool is available. Aborts when
+# none is found rather than skip verification.
+sha256_of() {
+    _f="$1"
+    if have sha256sum; then
+        sha256sum "$_f" | awk '{print $1}'
+    elif have shasum; then
+        shasum -a 256 "$_f" | awk '{print $1}'
+    elif have openssl; then
+        openssl dgst -sha256 "$_f" | awk '{print $NF}'
+    else
+        err "no SHA-256 tool (need sha256sum, shasum, or openssl); refusing to install unverified"
+    fi
+}
+
+extract() {
+    _archive="$1"
+    _dest="$2"
+    case "$_archive" in
+        *.tar.gz) tar -xzf "$_archive" -C "$_dest" ;;
+        *.zip)
+            have unzip || err "need 'unzip' to extract $_archive"
+            unzip -q "$_archive" -d "$_dest" ;;
+        *) err "unknown archive type: $_archive" ;;
+    esac
+}
+
+main() {
+    version="${GH_SECRETS_VERSION:-}"
+    bindir="${GH_SECRETS_INSTALL_DIR:-}"
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --version) version="${2:?--version needs a value}"; shift 2 ;;
+            --version=*) version="${1#*=}"; shift ;;
+            --to | --bin-dir) bindir="${2:?--to needs a value}"; shift 2 ;;
+            --to=* | --bin-dir=*) bindir="${1#*=}"; shift ;;
+            -h | --help) usage; exit 0 ;;
+            *) err "unknown option: $1 (try --help)" ;;
+        esac
+    done
+
+    [ -n "$bindir" ] || bindir="${HOME}/.local/bin"
+
+    if have curl; then
+        DL="curl"
+    elif have wget; then
+        DL="wget"
+    else
+        err "need curl or wget to download"
+    fi
+
+    detect_target
+
+    if [ -z "$version" ]; then
+        say "resolving latest release..."
+        version="$(latest_tag)"
+    fi
+
+    archive="${BIN}-${version}-${TARGET}.${EXT}"
+    # The release workflow names the checksum asset by appending `.sha256` to
+    # the full archive name, e.g. gh-secrets-v0.1.0-<target>.tar.gz.sha256.
+    sumfile="${archive}.sha256"
+    base_url="https://github.com/$REPO/releases/download/${version}"
+
+    tmp="$(mktemp -d 2>/dev/null || mktemp -d -t gh-secrets)" \
+        || err "could not create a temporary directory"
+    trap 'rm -rf "$tmp"' EXIT INT TERM
+
+    say "downloading ${archive} (${version})..."
+    download "${base_url}/${archive}" "${tmp}/${archive}" \
+        || err "download failed: ${base_url}/${archive}"
+    download "${base_url}/${sumfile}" "${tmp}/${sumfile}" \
+        || err "checksum download failed: ${base_url}/${sumfile}"
+
+    say "verifying checksum..."
+    expected="$(awk '{print $1}' "${tmp}/${sumfile}")"
+    actual="$(sha256_of "${tmp}/${archive}")"
+    [ -n "$expected" ] || err "empty checksum file for ${archive}"
+    [ "$expected" = "$actual" ] \
+        || err "checksum mismatch for ${archive} (expected ${expected}, got ${actual})"
+
+    mkdir -p "${tmp}/unpack"
+    extract "${tmp}/${archive}" "${tmp}/unpack"
+
+    src="${tmp}/unpack/${BIN_FILE}"
+    if [ ! -f "$src" ]; then
+        # The release workflow packs the binary under a leading directory
+        # (gh-secrets-<version>-<target>/), so search for it when it is not at
+        # the archive root.
+        src="$(find "${tmp}/unpack" -type f -name "$BIN_FILE" -print 2>/dev/null | head -n1)"
+        [ -n "$src" ] && [ -f "$src" ] || err "binary '$BIN_FILE' not found in ${archive}"
+    fi
+
+    mkdir -p "$bindir" || err "could not create install directory: $bindir"
+    dest="${bindir}/${BIN_FILE}"
+    if have install; then
+        install -m 0755 "$src" "$dest" || err "could not install to $dest"
+    else
+        cp "$src" "$dest" && chmod 0755 "$dest" || err "could not install to $dest"
+    fi
+
+    say "installed ${BIN} ${version} to ${dest}"
+
+    case ":${PATH}:" in
+        *":${bindir}:"*) ;;
+        *)
+            say ""
+            say "NOTE: ${bindir} is not on your PATH. Add it to your shell profile:"
+            say "  export PATH=\"${bindir}:\$PATH\""
+            ;;
+    esac
+}
+
+main "$@"

--- a/tests/e2e_live.rs
+++ b/tests/e2e_live.rs
@@ -11,8 +11,11 @@
 
 mod live_common;
 
+use std::process::Command as StdCommand;
+
 use live_common::{live_enabled, token, LiveSession, LIVE_ENV};
 use predicates::str::contains;
+use tempfile::TempDir;
 
 macro_rules! skip_if_no_live {
     () => {
@@ -184,6 +187,61 @@ fn live_repo_override_wins_during_sync() {
         .success()
         .stdout(contains(format!("created '{name}' in {}", s.repo)));
     assert!(s.remote_secret_names().contains(&name));
+}
+
+/// The cross-platform install script (`scripts/install.sh`) must download the
+/// real published release, verify its SHA-256 checksum, and drop a working
+/// binary onto the chosen PATH. This drives the canonical `curl ... | sh`
+/// experience end-to-end against GitHub: it resolves the latest release tag
+/// (passing `GITHUB_TOKEN` so the API call is not rate-limited), downloads and
+/// checksum-verifies the archive for this host platform, extracts it, and
+/// installs the binary, which we then run to prove it is functional.
+///
+/// Only meaningful on the platforms the script targets with a POSIX shell;
+/// `live-e2e` runs on Linux, where `sh`/`tar`/`sha256sum` are present.
+#[test]
+fn live_install_script_downloads_and_verifies_release() {
+    skip_if_no_live!();
+
+    let bindir = TempDir::new().expect("tempdir for install target");
+    let script = concat!(env!("CARGO_MANIFEST_DIR"), "/scripts/install.sh");
+
+    let output = StdCommand::new("sh")
+        .arg(script)
+        .arg("--to")
+        .arg(bindir.path())
+        // The script reads GITHUB_TOKEN (not GH_TOKEN) to authenticate the
+        // "latest release" API call and lift the unauthenticated rate limit.
+        .env("GITHUB_TOKEN", token())
+        .output()
+        .expect("run scripts/install.sh");
+
+    assert!(
+        output.status.success(),
+        "install.sh failed (status {:?}):\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    // The installed binary must run. The script names it `gh-secrets` on every
+    // platform the live job exercises (no `.exe` on Linux/macOS).
+    let installed = bindir.path().join("gh-secrets");
+    assert!(
+        installed.is_file(),
+        "expected installed binary at {}",
+        installed.display()
+    );
+    let version = StdCommand::new(&installed)
+        .arg("--version")
+        .output()
+        .expect("run installed gh-secrets --version");
+    assert!(version.status.success(), "installed binary failed to run");
+    let stdout = String::from_utf8_lossy(&version.stdout);
+    assert!(
+        stdout.contains("gh-secrets"),
+        "unexpected --version output: {stdout}"
+    );
 }
 
 /// Local-only removal must NOT touch the remote secret. The CLI deliberately


### PR DESCRIPTION
## What

Adds `scripts/install.sh`, a cross-platform installer modeled on
[`nickderobertis/allowlister`](https://github.com/nickderobertis/allowlister)'s
installer. It detects the host target, downloads the matching prebuilt release
archive, **verifies its SHA-256 checksum**, extracts it, and installs the binary
onto your PATH (default `~/.local/bin`).

```sh
curl -fsSL https://raw.githubusercontent.com/nickderobertis/github-secrets/master/scripts/install.sh | sh
```

Covers Linux and macOS (x86_64 + arm64) and Windows x86_64 under a POSIX shell
(Git Bash / MSYS / WSL). Supports `--version <tag>` / `--to <dir>` (and the
`GH_SECRETS_VERSION` / `GH_SECRETS_INSTALL_DIR` env equivalents), and reads
`GITHUB_TOKEN` to lift the API rate limit when resolving "latest". Like the tool
it installs, it aborts rather than install a binary it cannot checksum-verify.

## Adapted to this repo's release naming

The allowlister script was adapted to match `release.yml`:

- The checksum asset appends `.sha256` to the **full** archive name (it keeps
  the `.tar.gz`/`.zip`), e.g. `gh-secrets-v0.1.0-x86_64-unknown-linux-gnu.tar.gz.sha256`.
- The binary sits under a leading `gh-secrets-<tag>-<target>/` directory inside
  the archive; the script finds it there.

## Real e2e coverage

A new live e2e test, `live_install_script_downloads_and_verifies_release`
(`tests/e2e_live.rs`), runs the script against the **real** published GitHub
release on every CI run that has `GH_E2E_TOKEN`: it resolves the latest tag,
downloads + checksum-verifies the archive for the host platform, installs the
binary, and runs it. Off-live it early-returns as a no-op, so the default gate
stays network-free. This means a future drift between the installer and the
release asset naming fails the gate rather than only surfacing for a user.

Verified locally end-to-end against the existing `v0.1.0` release (download →
checksum → extract → install → `gh-secrets --version`).

## Also

- README install section documents the one-liner, version pinning, and the
  `cargo install` fallback.
- AGENTS.md records the installer ↔ release-naming invariant.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MQNQCp4QpQp1J3hYLUCwit)_