### PR TITLE
feat: auto-load .env/.env.local and add auth command for manifest credentials

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,11 +75,15 @@ they exercise it the way a user does.
 
 ## Config and paths
 
-The CLI reads two config files under a single root:
+The CLI reads these config files under a single root:
 
 - `<root>/app.json` — global app config (current profile, profile list).
 - `<root>/profiles/<name>.json` — per-profile state (GitHub token,
-  include/exclude lists, secrets, sync records).
+  include/exclude lists, secrets, sync records). Used by the profile flow.
+- `<root>/credentials.json` — profile-independent credential store for the
+  **manifest** flow (GitHub token + Bitwarden login), written by `gh-secrets
+  auth`. `0600` on Unix; treat as sensitive. It is the lowest-priority
+  credential layer (see the precedence below).
 
 The root is resolved as `$GH_SECRETS_HOME` if set, otherwise the platform
 config directory (`$XDG_CONFIG_HOME/gh-secrets` on Linux,
@@ -99,9 +103,25 @@ For the manifest-driven flow:
   destination) SHA-256 hashes that drive the "push only when changed" check.
   **Always gitignore this file** — losing it forces a re-push but leaks
   nothing.
-- The GitHub destination reads its token from `GH_TOKEN` (preferred) or
-  `GITHUB_TOKEN`. There is no per-manifest token field by design — the
-  manifest is checked in, the token is not.
+- Credential resolution for the manifest flow (the GitHub token *and* the
+  Bitwarden login) follows a single precedence: **shell env > `.env` >
+  `.env.local` > stored config**. `manifest sync` and `auth status` auto-load
+  `.env` then `.env.local` from the current directory into the process
+  environment, setting only keys that aren't already present — so a real shell
+  variable wins, then `.env`, then `.env.local`. The lowest layer is
+  `<root>/credentials.json`, written by `gh-secrets auth github <token>` and
+  `gh-secrets auth bitwarden --client-id/--client-secret/--master-password`;
+  `gh-secrets auth status` reports where each credential resolves from without
+  ever printing a value, and `gh-secrets auth clear [--github|--bitwarden]`
+  removes it. Dotenv auto-load is deliberately scoped to these
+  credential-consuming commands, not every invocation: the profile flow keeps
+  its token in its own config and never reads these vars, and a global load
+  would pull a developer's real `.env` into unrelated subprocesses (the test
+  suites run with the repo root as CWD, where a real `.env` lives).
+- The GitHub destination has no per-manifest token field by design — the
+  manifest is checked in, the token is not. The token resolves via the
+  precedence above (`GH_TOKEN` preferred, then `GITHUB_TOKEN`, then stored
+  config).
 - The Bitwarden source shells out to the `bw` (password-manager) CLI, which
   must be on `$PATH` (`npm install -g @bitwarden/cli` or
   `brew install bitwarden-cli`). In a fresh environment (CI) it expects
@@ -115,8 +135,13 @@ For the manifest-driven flow:
   canonical `BW_*` name is unset: `BITWARDEN_CLIENT_ID`,
   `BITWARDEN_CLIENT_SECRET`, `BITWARDEN_MASTER_PASSWORD` (or
   `BITWARDEN_PASSWORD`), and `BITWARDEN_SESSION`. The canonical name wins when
-  both are set; an empty value counts as unset. The tool does **not** auto-load
-  a `.env` — export the vars first (e.g. `set -a; . .env; set +a`).
+  both are set; an empty value counts as unset. These vars follow the
+  precedence above: `manifest sync` auto-loads `.env`/`.env.local`, and any
+  field still unset then falls back to the `gh-secrets auth bitwarden` stored
+  config. Whatever layer supplies a value, the `bw` subprocess always receives
+  it under the canonical `BW_*` name. `BW_SESSION`/`BITWARDEN_SESSION` is the
+  one credential never read from stored config — it's an ephemeral unlock
+  token, not a durable credential.
 - A second test-only override, `GH_SECRETS_TEST_SOURCE_FILE`, points the
   manifest's source resolver at a JSON file `{ "NAME": "value", ... }`
   instead of contacting Bitwarden. Used exclusively by `tests/e2e_manifest.rs`
@@ -158,6 +183,15 @@ For the manifest-driven flow:
   re-sync of unchanged values produces zero new PUTs and zero env-file
   writes; verifies a source-side value change repushes only the affected
   secret. Bitwarden itself is unit-tested against a mock `BwCli`.
+- The auth e2e suite (`tests/e2e_auth.rs`) drives the `gh-secrets auth` command
+  group and proves the credential precedence end-to-end: `auth status` reports
+  provenance without printing values; storing/clearing round-trips through
+  `credentials.json` (and the file is `0600`); and — the key assertion — a real
+  `manifest sync` against a wiremock GitHub records the exact `Authorization`
+  bearer, so each test can confirm the token that *won* (shell env, `.env`,
+  `.env.local`, or stored config) is the one that actually reached the API. The
+  dotenv parser/precedence planner is also unit-tested in `src/envfile.rs`, and
+  the env→stored merge in `src/credentials.rs`.
 
 ## Conventional Commits
 

--- a/justfile
+++ b/justfile
@@ -24,7 +24,7 @@ test:
 # early-returns as a no-op when `GH_SECRETS_LIVE_TEST` is unset, so the gate
 # catches breakage in the live test code without paying for network calls.
 test-e2e:
-    cargo nextest run --test e2e --test e2e_manifest --test e2e_live
+    cargo nextest run --test e2e --test e2e_manifest --test e2e_auth --test e2e_live
 
 # Live end-to-end tests against the real GitHub API. Requires `GH_TOKEN` with
 # `repo` scope (covers `secrets:write`); creates and reuses a private sandbox

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,14 +1,18 @@
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use clap::{Args, Parser, Subcommand};
 
 use crate::config::{load_active_profile, ProfileConfig};
-use crate::destinations::DestinationReport;
+use crate::credentials::StoredCredentials;
+use crate::destinations::{DestinationReport, GITHUB_TOKEN_ENVS};
+use crate::envfile;
 use crate::github::GitHubClient;
 use crate::manifest::{RepoManifest, DEFAULT_MANIFEST_FILE};
 use crate::paths::Paths;
 use crate::secrets::Upsert;
+use crate::sources::{BW_CLIENTID_ENVS, BW_CLIENTSECRET_ENVS, BW_PASSWORD_ENVS, BW_SESSION_ENVS};
 use crate::sync::{self, SyncReport};
 use crate::sync_manifest::{self, ManifestSyncReport};
 
@@ -58,6 +62,49 @@ enum Command {
     Manifest {
         #[command(subcommand)]
         command: ManifestCmd,
+    },
+    /// Store credentials for the manifest flow (GitHub token, Bitwarden login)
+    /// as the lowest-priority fallback. Resolution order is: shell env > .env >
+    /// .env.local > this stored config.
+    Auth {
+        #[command(subcommand)]
+        command: AuthCmd,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum AuthCmd {
+    /// Store a GitHub token used by manifest `github` destinations.
+    Github {
+        /// Personal access token with `repo` scope (or fine-grained
+        /// `secrets:write`).
+        token: String,
+    },
+    /// Store Bitwarden login material (personal API key + master password).
+    /// Each flag is optional; only the ones you pass are updated.
+    Bitwarden {
+        /// Bitwarden personal API key client id (the `user.<uuid>` value).
+        #[arg(long)]
+        client_id: Option<String>,
+        /// Bitwarden personal API key client secret.
+        #[arg(long)]
+        client_secret: Option<String>,
+        /// Bitwarden master password (still required to unlock the vault even
+        /// with an API key).
+        #[arg(long)]
+        master_password: Option<String>,
+    },
+    /// Show where each credential resolves from (env, .env, .env.local, or
+    /// stored config) without ever printing its value.
+    Status,
+    /// Remove stored credentials. With no flag, clears everything.
+    Clear {
+        /// Only clear the stored GitHub token.
+        #[arg(long)]
+        github: bool,
+        /// Only clear the stored Bitwarden login.
+        #[arg(long)]
+        bitwarden: bool,
     },
 }
 
@@ -325,11 +372,76 @@ pub fn run() -> Result<()> {
                 println!("manifest: wrote starter to {}", target.display());
             }
             ManifestCmd::Sync { config, state } => {
+                // Make `.env`/`.env.local` in the working directory available as
+                // credentials before resolving the source/destinations.
+                envfile::load_dotenv_cwd();
                 let manifest_path = config.unwrap_or_else(|| PathBuf::from(DEFAULT_MANIFEST_FILE));
                 let report = sync_manifest::sync_manifest(&manifest_path, state.as_deref())?;
                 print_manifest_report(&report);
             }
         },
+
+        Command::Auth { command } => {
+            let creds_path = paths.credentials_file();
+            let mut stored = StoredCredentials::load(&creds_path)?;
+            match command {
+                AuthCmd::Github { token } => {
+                    if token.is_empty() {
+                        anyhow::bail!("token cannot be empty");
+                    }
+                    stored.github_token = Some(token);
+                    stored.save(&creds_path)?;
+                    println!("auth: stored GitHub token");
+                }
+                AuthCmd::Bitwarden {
+                    client_id,
+                    client_secret,
+                    master_password,
+                } => {
+                    if client_id.is_none() && client_secret.is_none() && master_password.is_none() {
+                        anyhow::bail!(
+                            "provide at least one of --client-id, --client-secret, --master-password"
+                        );
+                    }
+                    let mut set = Vec::new();
+                    if let Some(v) = client_id {
+                        stored.bitwarden.client_id = Some(v);
+                        set.push("client id");
+                    }
+                    if let Some(v) = client_secret {
+                        stored.bitwarden.client_secret = Some(v);
+                        set.push("client secret");
+                    }
+                    if let Some(v) = master_password {
+                        stored.bitwarden.master_password = Some(v);
+                        set.push("master password");
+                    }
+                    stored.save(&creds_path)?;
+                    println!("auth: stored Bitwarden {}", set.join(", "));
+                }
+                AuthCmd::Status => {
+                    let origins = envfile::load_dotenv_cwd();
+                    print_auth_status(&origins, &stored);
+                }
+                AuthCmd::Clear { github, bitwarden } => {
+                    // No flag means clear everything.
+                    let clear_all = !github && !bitwarden;
+                    if github || clear_all {
+                        stored.github_token = None;
+                    }
+                    if bitwarden || clear_all {
+                        stored.bitwarden = Default::default();
+                    }
+                    if stored.is_empty() && creds_path.exists() {
+                        std::fs::remove_file(&creds_path)
+                            .with_context(|| format!("removing {}", creds_path.display()))?;
+                    } else {
+                        stored.save(&creds_path)?;
+                    }
+                    println!("auth: cleared stored credentials");
+                }
+            }
+        }
     }
 
     if profile_dirty {
@@ -355,6 +467,66 @@ fn scope_label(repo: Option<&str>) -> String {
     match repo {
         Some(r) => format!("repo '{r}'"),
         None => "global".to_string(),
+    }
+}
+
+/// Report where each manifest credential resolves from, without ever printing
+/// a value (honoring the "never print a secret" invariant — tokens and the
+/// master password are secrets too).
+fn print_auth_status(origins: &BTreeMap<String, &'static str>, stored: &StoredCredentials) {
+    println!("auth status (priority: shell env > .env > .env.local > stored config):");
+    let rows: [(&str, &[&str], Option<&str>); 5] = [
+        (
+            "GitHub token",
+            GITHUB_TOKEN_ENVS,
+            stored.github_token.as_deref(),
+        ),
+        (
+            "Bitwarden client id",
+            BW_CLIENTID_ENVS,
+            stored.bitwarden.client_id.as_deref(),
+        ),
+        (
+            "Bitwarden client secret",
+            BW_CLIENTSECRET_ENVS,
+            stored.bitwarden.client_secret.as_deref(),
+        ),
+        (
+            "Bitwarden master password",
+            BW_PASSWORD_ENVS,
+            stored.bitwarden.master_password.as_deref(),
+        ),
+        // The unlock session is read from the environment only, never stored.
+        ("Bitwarden session", BW_SESSION_ENVS, None),
+    ];
+    for (label, names, stored_value) in rows {
+        println!(
+            "  {label}: {}",
+            describe_source(names, origins, stored_value)
+        );
+    }
+}
+
+fn describe_source(
+    names: &[&str],
+    origins: &BTreeMap<String, &'static str>,
+    stored: Option<&str>,
+) -> String {
+    for name in names {
+        match std::env::var_os(name) {
+            Some(v) if !v.is_empty() => {
+                return match origins.get(*name) {
+                    Some(file) => format!("set (from {file})"),
+                    None => "set (from your shell environment)".to_string(),
+                };
+            }
+            _ => {}
+        }
+    }
+    if stored.is_some_and(|s| !s.is_empty()) {
+        "set (from stored config)".to_string()
+    } else {
+        "not set".to_string()
     }
 }
 

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -1,0 +1,192 @@
+//! Stored credentials for the manifest flow + the resolution that layers the
+//! environment over them.
+//!
+//! Precedence (highest first): shell env, then `.env`, then `.env.local` (all
+//! three already collapsed into the process environment by
+//! [`crate::envfile::load_dotenv_cwd`]), then this stored config file. The
+//! resolver here implements only the final `env → stored` step; the dotenv
+//! layering happens before it runs.
+//!
+//! The file lives at `<config-root>/credentials.json` (profile-independent,
+//! because `manifest sync` is independent of the active profile) and is written
+//! `0600` on Unix. It is the *only* place — besides the env vars — a user opts
+//! into persisting these credentials; treat its contents as sensitive.
+
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::destinations::github_token_from_env;
+use crate::sources::BitwardenCredentials;
+
+/// On-disk credential store. Every field is optional so a user can persist only
+/// what they want (e.g. just the Bitwarden API key, keeping the GitHub token in
+/// CI env).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StoredCredentials {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub github_token: Option<String>,
+    #[serde(default, skip_serializing_if = "StoredBitwarden::is_empty")]
+    pub bitwarden: StoredBitwarden,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StoredBitwarden {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_secret: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub master_password: Option<String>,
+}
+
+impl StoredBitwarden {
+    pub fn is_empty(&self) -> bool {
+        self.client_id.is_none() && self.client_secret.is_none() && self.master_password.is_none()
+    }
+}
+
+impl StoredCredentials {
+    pub fn load(path: &Path) -> Result<Self> {
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+        let bytes = fs::read(path).with_context(|| format!("reading {}", path.display()))?;
+        serde_json::from_slice(&bytes).with_context(|| format!("parsing {}", path.display()))
+    }
+
+    pub fn save(&self, path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+        }
+        let bytes = serde_json::to_vec_pretty(self).context("serializing credentials")?;
+        let tmp = path.with_extension("json.tmp");
+        fs::write(&tmp, &bytes).with_context(|| format!("writing {}", tmp.display()))?;
+        set_owner_only(&tmp)?;
+        fs::rename(&tmp, path)
+            .with_context(|| format!("renaming {} -> {}", tmp.display(), path.display()))?;
+        Ok(())
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.github_token.is_none() && self.bitwarden.is_empty()
+    }
+}
+
+#[cfg(unix)]
+fn set_owner_only(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+        .with_context(|| format!("setting 0600 perms on {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn set_owner_only(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+/// Fully resolved manifest credentials: the environment (incl. loaded dotenv)
+/// over stored config.
+#[derive(Debug, Clone, Default)]
+pub struct ResolvedCredentials {
+    pub github_token: Option<String>,
+    pub bitwarden: BitwardenCredentials,
+}
+
+impl ResolvedCredentials {
+    pub fn resolve(stored: &StoredCredentials) -> Self {
+        Self {
+            github_token: github_token_from_env()
+                .or_else(|| stored.github_token.clone().filter(|s| !s.is_empty())),
+            bitwarden: BitwardenCredentials::from_env().or_stored(
+                stored.bitwarden.client_id.as_deref(),
+                stored.bitwarden.client_secret.as_deref(),
+                stored.bitwarden.master_password.as_deref(),
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn round_trips_and_omits_empty_sections() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("credentials.json");
+        let creds = StoredCredentials {
+            github_token: Some("ghp_x".into()),
+            ..Default::default()
+        };
+        creds.save(&path).unwrap();
+        // The empty bitwarden section is skipped entirely.
+        let raw = fs::read_to_string(&path).unwrap();
+        assert!(raw.contains("github_token"));
+        assert!(!raw.contains("bitwarden"));
+        let back = StoredCredentials::load(&path).unwrap();
+        assert_eq!(creds, back);
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = fs::metadata(&path).unwrap().permissions().mode();
+            assert_eq!(mode & 0o777, 0o600);
+        }
+    }
+
+    #[test]
+    fn missing_file_loads_as_default() {
+        let dir = TempDir::new().unwrap();
+        let got = StoredCredentials::load(&dir.path().join("nope.json")).unwrap();
+        assert_eq!(got, StoredCredentials::default());
+        assert!(got.is_empty());
+    }
+
+    #[test]
+    fn resolve_falls_back_to_stored_when_env_absent() {
+        // Ensure the env doesn't accidentally provide these (nextest isolates
+        // each test in its own process, so this is safe).
+        for k in [
+            "GH_TOKEN",
+            "GITHUB_TOKEN",
+            "BW_CLIENTID",
+            "BITWARDEN_CLIENT_ID",
+            "BW_CLIENTSECRET",
+            "BITWARDEN_CLIENT_SECRET",
+            "BW_PASSWORD",
+            "BITWARDEN_MASTER_PASSWORD",
+            "BITWARDEN_PASSWORD",
+            "BW_SESSION",
+            "BITWARDEN_SESSION",
+        ] {
+            std::env::remove_var(k);
+        }
+        let stored = StoredCredentials {
+            github_token: Some("stored-gh".into()),
+            bitwarden: StoredBitwarden {
+                client_id: Some("stored-id".into()),
+                client_secret: Some("stored-secret".into()),
+                master_password: Some("stored-pw".into()),
+            },
+        };
+        let resolved = ResolvedCredentials::resolve(&stored);
+        assert_eq!(resolved.github_token.as_deref(), Some("stored-gh"));
+        assert_eq!(resolved.bitwarden.client_id.as_deref(), Some("stored-id"));
+        assert_eq!(resolved.bitwarden.password.as_deref(), Some("stored-pw"));
+
+        // Now the environment must win over stored config.
+        std::env::set_var("GH_TOKEN", "env-gh");
+        std::env::set_var("BW_PASSWORD", "env-pw");
+        let resolved = ResolvedCredentials::resolve(&stored);
+        assert_eq!(resolved.github_token.as_deref(), Some("env-gh"));
+        assert_eq!(resolved.bitwarden.password.as_deref(), Some("env-pw"));
+        // The fields the env didn't set still come from stored config.
+        assert_eq!(resolved.bitwarden.client_id.as_deref(), Some("stored-id"));
+        std::env::remove_var("GH_TOKEN");
+        std::env::remove_var("BW_PASSWORD");
+    }
+}

--- a/src/destinations.rs
+++ b/src/destinations.rs
@@ -11,7 +11,7 @@ use std::env;
 use std::fs;
 use std::path::PathBuf;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 
 use crate::github::GitHubClient;
 use crate::manifest::{EnvFileDestinationConfig, GithubDestinationConfig};
@@ -62,9 +62,12 @@ pub struct GitHubDestination {
 }
 
 impl GitHubDestination {
-    pub fn from_config(config: &GithubDestinationConfig) -> Result<Self> {
-        let token = github_token_from_env()?;
-        let client = GitHubClient::new(&token).context("building GitHub client")?;
+    /// Build from a manifest github destination and an already-resolved token.
+    /// Token resolution (env → stored config) lives in `crate::credentials` so
+    /// every credential follows the same precedence; this just consumes the
+    /// result.
+    pub fn from_config(config: &GithubDestinationConfig, token: &str) -> Result<Self> {
+        let client = GitHubClient::new(token).context("building GitHub client")?;
         Ok(Self {
             repository: config.repository.clone(),
             client,
@@ -76,18 +79,18 @@ impl GitHubDestination {
     }
 }
 
-pub fn github_token_from_env() -> Result<String> {
+/// First non-empty GitHub token among the canonical env vars (`GH_TOKEN`,
+/// `GITHUB_TOKEN`), including any value loaded from `.env`/`.env.local`. Returns
+/// `None` so the caller can fall back to stored config before erroring.
+pub fn github_token_from_env() -> Option<String> {
     for name in GITHUB_TOKEN_ENVS {
         if let Ok(v) = env::var(name) {
             if !v.is_empty() {
-                return Ok(v);
+                return Some(v);
             }
         }
     }
-    Err(anyhow!(
-        "no GitHub token in environment; set one of: {}",
-        GITHUB_TOKEN_ENVS.join(", ")
-    ))
+    None
 }
 
 impl Destination for GitHubDestination {

--- a/src/envfile.rs
+++ b/src/envfile.rs
@@ -1,0 +1,257 @@
+//! Auto-loading of `.env` / `.env.local` from the current directory.
+//!
+//! Credential resolution for the manifest flow follows the precedence
+//!
+//! ```text
+//! shell env  >  .env  >  .env.local  >  config file
+//! ```
+//!
+//! The first three layers are realized here by loading the dotenv files *into
+//! the process environment*, but only for keys that aren't already set. Loading
+//! `.env` before `.env.local` (and never overwriting an existing value) yields
+//! exactly that order: a real shell variable always wins, then `.env`, then
+//! `.env.local`. The `> config file` tail is applied later, in
+//! `crate::credentials`, by treating the (now dotenv-populated) environment as
+//! the high-priority layer and stored config as the fallback.
+//!
+//! Loading is intentionally scoped to the commands that consume credentials
+//! (`manifest sync`, `auth status`) rather than every invocation: the
+//! profile-based flow keeps its token in its own config and never reads these
+//! env vars, and a global load would pull a developer's real `.env` into
+//! unrelated subprocesses.
+
+use std::collections::BTreeMap;
+use std::env;
+use std::fs;
+use std::path::Path;
+
+/// The two files we look for, in priority order (earlier wins).
+const DOTENV_FILES: &[(&str, &str)] = &[
+    (".env", "the .env file"),
+    (".env.local", "the .env.local file"),
+];
+
+/// Load `.env` then `.env.local` from the current directory into the process
+/// environment, setting only keys that aren't already present (so the real
+/// shell environment and earlier files win). Returns, for each key this call
+/// actually set, the human-readable name of the file it came from — used by
+/// `auth status` to explain provenance.
+pub fn load_dotenv_cwd() -> BTreeMap<String, &'static str> {
+    let plan = plan_dotenv_load(Path::new("."), |k| env::var_os(k).is_some());
+    let mut origins = BTreeMap::new();
+    for (key, value, origin) in plan {
+        // Edition 2021: `set_var` is safe. We only ever set keys we proved are
+        // currently unset, so this never clobbers a shell-provided value.
+        env::set_var(&key, &value);
+        origins.insert(key, origin);
+    }
+    origins
+}
+
+/// Pure planner: decide which keys to set and from which file, given a way to
+/// ask whether a key is already present in the *external* environment. Keeps
+/// the precedence logic testable without mutating global state.
+///
+/// `shell_has(key)` must answer for the real environment only; cross-file
+/// precedence (`.env` beats `.env.local`) is tracked internally.
+fn plan_dotenv_load(
+    dir: &Path,
+    shell_has: impl Fn(&str) -> bool,
+) -> Vec<(String, String, &'static str)> {
+    // key -> (value, origin); first file to claim a key keeps it.
+    let mut planned: BTreeMap<String, (String, &'static str)> = BTreeMap::new();
+    for (file, origin) in DOTENV_FILES {
+        let Ok(content) = fs::read_to_string(dir.join(file)) else {
+            continue;
+        };
+        // Within a single file, the last assignment of a key wins (dotenv
+        // convention); fold before applying cross-layer precedence.
+        let mut per_file: BTreeMap<String, String> = BTreeMap::new();
+        for (k, v) in parse_dotenv(&content) {
+            per_file.insert(k, v);
+        }
+        for (k, v) in per_file {
+            if shell_has(&k) || planned.contains_key(&k) {
+                continue;
+            }
+            planned.insert(k, (v, origin));
+        }
+    }
+    planned
+        .into_iter()
+        .map(|(k, (v, origin))| (k, v, origin))
+        .collect()
+}
+
+/// Parse dotenv text into `(key, value)` pairs in file order. Lenient: blank
+/// lines, comments, and anything that doesn't look like an assignment are
+/// skipped rather than erroring, because these files are hand-authored.
+pub fn parse_dotenv(content: &str) -> Vec<(String, String)> {
+    content.lines().filter_map(parse_dotenv_line).collect()
+}
+
+/// Parse one line into `(key, value)`, or `None` for blanks/comments/garbage.
+/// Understands an optional `export ` prefix, whitespace around `=`, and
+/// double-quoted (with the same escapes `format_env_line` emits), single-quoted
+/// (literal), or bare values.
+fn parse_dotenv_line(line: &str) -> Option<(String, String)> {
+    let trimmed = line.trim_start();
+    if trimmed.is_empty() || trimmed.starts_with('#') {
+        return None;
+    }
+    let rest = trimmed
+        .strip_prefix("export ")
+        .map(str::trim_start)
+        .unwrap_or(trimmed);
+    let eq = rest.find('=')?;
+    let key = rest[..eq].trim_end();
+    if !is_valid_key(key) {
+        return None;
+    }
+    let raw_value = rest[eq + 1..].trim();
+    Some((key.to_string(), unquote(raw_value)))
+}
+
+/// A POSIX-ish env var name: starts with a letter or `_`, then alphanumerics or
+/// `_`. Mirrors `destinations::parse_env_key` so reads and writes agree.
+fn is_valid_key(key: &str) -> bool {
+    let mut chars = key.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// Unquote a dotenv value. Double quotes honor the escapes our writer emits
+/// (`\n \r \t \\ \" \$ \``); single quotes are literal; bare values are taken
+/// verbatim (already trimmed by the caller).
+fn unquote(raw: &str) -> String {
+    let bytes = raw.as_bytes();
+    if raw.len() >= 2 && bytes[0] == b'"' && bytes[raw.len() - 1] == b'"' {
+        unescape_double(&raw[1..raw.len() - 1])
+    } else if raw.len() >= 2 && bytes[0] == b'\'' && bytes[raw.len() - 1] == b'\'' {
+        raw[1..raw.len() - 1].to_string()
+    } else {
+        raw.to_string()
+    }
+}
+
+fn unescape_double(inner: &str) -> String {
+    let mut out = String::with_capacity(inner.len());
+    let mut chars = inner.chars();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some('n') => out.push('\n'),
+            Some('r') => out.push('\r'),
+            Some('t') => out.push('\t'),
+            Some('\\') => out.push('\\'),
+            Some('"') => out.push('"'),
+            Some('$') => out.push('$'),
+            Some('`') => out.push('`'),
+            // Unknown escape: keep the backslash and the char literally.
+            Some(other) => {
+                out.push('\\');
+                out.push(other);
+            }
+            None => out.push('\\'),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use tempfile::TempDir;
+
+    #[test]
+    fn parses_common_line_shapes() {
+        assert_eq!(
+            parse_dotenv_line("FOO=bar"),
+            Some(("FOO".into(), "bar".into()))
+        );
+        assert_eq!(
+            parse_dotenv_line("export FOO=bar"),
+            Some(("FOO".into(), "bar".into()))
+        );
+        assert_eq!(
+            parse_dotenv_line("  FOO = bar "),
+            Some(("FOO".into(), "bar".into()))
+        );
+        assert_eq!(parse_dotenv_line("# comment"), None);
+        assert_eq!(parse_dotenv_line(""), None);
+        assert_eq!(parse_dotenv_line("   "), None);
+        assert_eq!(parse_dotenv_line("not an assignment"), None);
+        assert_eq!(parse_dotenv_line("1BAD=x"), None);
+        assert_eq!(parse_dotenv_line("BAD-KEY=x"), None);
+    }
+
+    #[test]
+    fn unquotes_round_tripping_our_writer() {
+        // Mirrors `destinations::format_env_line` so a value we wrote reads back
+        // identically.
+        assert_eq!(
+            parse_dotenv_line(r#"K="v""#),
+            Some(("K".into(), "v".into()))
+        );
+        assert_eq!(
+            parse_dotenv_line(r#"K="a\"b\\c\$d\`e""#),
+            Some(("K".into(), r#"a"b\c$d`e"#.into()))
+        );
+        assert_eq!(
+            parse_dotenv_line(r#"K="a\nb\tc""#),
+            Some(("K".into(), "a\nb\tc".into()))
+        );
+        // Single quotes are literal.
+        assert_eq!(
+            parse_dotenv_line(r#"K='a\nb'"#),
+            Some(("K".into(), r#"a\nb"#.into()))
+        );
+    }
+
+    #[test]
+    fn last_assignment_wins_within_a_file() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join(".env"), "K=first\nK=second\n").unwrap();
+        let plan = plan_dotenv_load(dir.path(), |_| false);
+        assert_eq!(plan, vec![("K".into(), "second".into(), "the .env file")]);
+    }
+
+    #[test]
+    fn shell_env_beats_both_files() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join(".env"), "SHELLVAR=fromenv\nONLYENV=e\n").unwrap();
+        fs::write(dir.path().join(".env.local"), "SHELLVAR=fromlocal\n").unwrap();
+        let shell: HashSet<&str> = ["SHELLVAR"].into_iter().collect();
+        let plan = plan_dotenv_load(dir.path(), |k| shell.contains(k));
+        // SHELLVAR is owned by the shell and must not be planned at all.
+        assert_eq!(plan, vec![("ONLYENV".into(), "e".into(), "the .env file")]);
+    }
+
+    #[test]
+    fn dotenv_beats_dotenv_local() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join(".env"), "K=from_env\n").unwrap();
+        fs::write(dir.path().join(".env.local"), "K=from_local\nONLYLOCAL=l\n").unwrap();
+        let plan = plan_dotenv_load(dir.path(), |_| false);
+        assert_eq!(
+            plan,
+            vec![
+                ("K".into(), "from_env".into(), "the .env file"),
+                ("ONLYLOCAL".into(), "l".into(), "the .env.local file"),
+            ]
+        );
+    }
+
+    #[test]
+    fn missing_files_are_not_an_error() {
+        let dir = TempDir::new().unwrap();
+        assert!(plan_dotenv_load(dir.path(), |_| false).is_empty());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,9 @@
 
 pub mod cli;
 pub mod config;
+pub mod credentials;
 pub mod destinations;
+pub mod envfile;
 pub mod github;
 pub mod manifest;
 pub mod paths;

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -35,6 +35,13 @@ impl Paths {
         self.root.join("app.json")
     }
 
+    /// Profile-independent credential store for the manifest flow (GitHub token
+    /// and Bitwarden login). Lives at the config root, not under `profiles/`,
+    /// since `manifest sync` is independent of the active profile.
+    pub fn credentials_file(&self) -> PathBuf {
+        self.root.join("credentials.json")
+    }
+
     pub fn profiles_dir(&self) -> PathBuf {
         self.root.join("profiles")
     }

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -96,10 +96,54 @@ pub const BW_SESSION_ENVS: &[&str] = &[BW_SESSION_ENV, "BITWARDEN_SESSION"];
 /// First non-empty value among `names`. Treats an env var set to the empty
 /// string as unset so we never hand `bw` a blank password (which would make it
 /// fall back to an interactive prompt against a closed stdin).
-fn env_first(names: &[&str]) -> Option<String> {
+pub fn env_first(names: &[&str]) -> Option<String> {
     names
         .iter()
         .find_map(|n| env::var(n).ok().filter(|v| !v.is_empty()))
+}
+
+/// Resolved Bitwarden login material handed to a `BitwardenSource`. Each field
+/// is optional so the caller can fill it from the environment, fall back to
+/// stored config, or leave it unset (and let `ensure_session` produce a precise
+/// error). `session`, when present, short-circuits login/unlock entirely.
+#[derive(Debug, Clone, Default)]
+pub struct BitwardenCredentials {
+    pub client_id: Option<String>,
+    pub client_secret: Option<String>,
+    pub password: Option<String>,
+    pub session: Option<String>,
+}
+
+impl BitwardenCredentials {
+    /// Read every field from the process environment (which includes any
+    /// `.env`/`.env.local` already loaded), honoring the canonical `BW_*` names
+    /// and their `BITWARDEN_*` aliases.
+    pub fn from_env() -> Self {
+        Self {
+            client_id: env_first(BW_CLIENTID_ENVS),
+            client_secret: env_first(BW_CLIENTSECRET_ENVS),
+            password: env_first(BW_PASSWORD_ENVS),
+            session: env_first(BW_SESSION_ENVS),
+        }
+    }
+
+    /// Fill any field still unset from stored config. `session` is deliberately
+    /// never sourced from config — it's an ephemeral unlock token, not a
+    /// durable credential.
+    pub fn or_stored(
+        mut self,
+        client_id: Option<&str>,
+        client_secret: Option<&str>,
+        password: Option<&str>,
+    ) -> Self {
+        fn nonempty(v: Option<&str>) -> Option<String> {
+            v.filter(|s| !s.is_empty()).map(String::from)
+        }
+        self.client_id = self.client_id.or_else(|| nonempty(client_id));
+        self.client_secret = self.client_secret.or_else(|| nonempty(client_secret));
+        self.password = self.password.or_else(|| nonempty(password));
+        self
+    }
 }
 
 /// Thin layer over the `bw` CLI. Exists so the field-extraction and error
@@ -211,54 +255,69 @@ impl BwCli for RealBwCli {
 pub struct BitwardenSource<C: BwCli = RealBwCli> {
     config: BitwardenSourceConfig,
     cli: C,
-    /// If set, used instead of running login/unlock. Useful when the caller
-    /// already has an unlocked session.
-    session_override: Option<String>,
+    /// Resolved login material. A present `session` short-circuits login/unlock.
+    credentials: BitwardenCredentials,
 }
 
 impl BitwardenSource<RealBwCli> {
+    /// Build a source whose credentials come from the environment only. The
+    /// manifest orchestrator instead uses [`with_credentials`] so it can layer
+    /// stored config under the environment.
     pub fn new(config: BitwardenSourceConfig) -> Self {
+        Self::with_credentials(config, BitwardenCredentials::from_env())
+    }
+
+    pub fn with_credentials(
+        config: BitwardenSourceConfig,
+        credentials: BitwardenCredentials,
+    ) -> Self {
         Self {
             config,
             cli: RealBwCli,
-            session_override: env_first(BW_SESSION_ENVS),
+            credentials,
         }
     }
 }
 
 impl<C: BwCli> BitwardenSource<C> {
-    pub fn with_cli(config: BitwardenSourceConfig, cli: C, session: Option<String>) -> Self {
+    pub fn with_cli(
+        config: BitwardenSourceConfig,
+        cli: C,
+        credentials: BitwardenCredentials,
+    ) -> Self {
         Self {
             config,
             cli,
-            session_override: session,
+            credentials,
         }
     }
 
     fn ensure_session(&self) -> Result<String> {
-        if let Some(s) = &self.session_override {
+        if let Some(s) = &self.credentials.session {
             return Ok(s.clone());
         }
         let status = self.cli.status().context("checking `bw status`")?;
         if status == BwStatus::Unauthenticated {
-            let client_id = env_first(BW_CLIENTID_ENVS).ok_or_else(|| {
-                anyhow!("set {BW_CLIENTID_ENV} (or BITWARDEN_CLIENT_ID) to log in to Bitwarden")
-            })?;
-            let client_secret = env_first(BW_CLIENTSECRET_ENVS).ok_or_else(|| {
+            let client_id = self.credentials.client_id.as_deref().ok_or_else(|| {
                 anyhow!(
-                    "set {BW_CLIENTSECRET_ENV} (or BITWARDEN_CLIENT_SECRET) to log in to Bitwarden"
+                    "no Bitwarden client id: set {BW_CLIENTID_ENV} (or BITWARDEN_CLIENT_ID, e.g. in .env) or run `gh-secrets auth bitwarden --client-id <id>`"
+                )
+            })?;
+            let client_secret = self.credentials.client_secret.as_deref().ok_or_else(|| {
+                anyhow!(
+                    "no Bitwarden client secret: set {BW_CLIENTSECRET_ENV} (or BITWARDEN_CLIENT_SECRET, e.g. in .env) or run `gh-secrets auth bitwarden --client-secret <secret>`"
                 )
             })?;
             self.cli
-                .login_apikey(&client_id, &client_secret)
+                .login_apikey(client_id, client_secret)
                 .context("`bw login --apikey` failed")?;
         }
-        let password = env_first(BW_PASSWORD_ENVS).ok_or_else(|| {
+        let password = self.credentials.password.as_deref().ok_or_else(|| {
             anyhow!(
-                "set {BW_PASSWORD_ENV} (or BITWARDEN_MASTER_PASSWORD) to unlock the Bitwarden vault"
+                "no Bitwarden master password: set {BW_PASSWORD_ENV} (or BITWARDEN_MASTER_PASSWORD, e.g. in .env) or run `gh-secrets auth bitwarden --master-password <pw>`"
             )
         })?;
-        let session = self.cli.unlock(&password).context("`bw unlock` failed")?;
+        let session = self.cli.unlock(password).context("`bw unlock` failed")?;
         self.cli.sync(&session).context("`bw sync` failed")?;
         Ok(session)
     }
@@ -426,7 +485,8 @@ mod tests {
         std::env::set_var(BW_CLIENTSECRET_ENV, "sec");
         std::env::set_var(BW_PASSWORD_ENV, "pw");
         std::env::remove_var(BW_SESSION_ENV);
-        let src = BitwardenSource::with_cli(BitwardenSourceConfig::default(), mock, None);
+        let creds = BitwardenCredentials::from_env();
+        let src = BitwardenSource::with_cli(BitwardenSourceConfig::default(), mock, creds);
         let secrets = vec![ManifestSecret {
             name: "STRIPE".into(),
             item: Some("stripe".into()),
@@ -461,6 +521,28 @@ mod tests {
     }
 
     #[test]
+    fn or_stored_fills_only_missing_fields_and_never_session() {
+        // Env provided only the client id; stored config provides the rest.
+        let from_env = BitwardenCredentials {
+            client_id: Some("env-id".into()),
+            session: Some("env-session".into()),
+            ..Default::default()
+        };
+        let merged =
+            from_env.or_stored(Some("stored-id"), Some("stored-secret"), Some("stored-pw"));
+        // Env wins for client id...
+        assert_eq!(merged.client_id.as_deref(), Some("env-id"));
+        // ...stored fills the gaps...
+        assert_eq!(merged.client_secret.as_deref(), Some("stored-secret"));
+        assert_eq!(merged.password.as_deref(), Some("stored-pw"));
+        // ...and session is left exactly as the env had it (never from stored).
+        assert_eq!(merged.session.as_deref(), Some("env-session"));
+        // An empty stored value counts as unset.
+        let empty = BitwardenCredentials::default().or_stored(Some(""), None, None);
+        assert_eq!(empty.client_id, None);
+    }
+
+    #[test]
     fn bitwarden_source_accepts_bitwarden_prefixed_aliases() {
         let mut items = HashMap::new();
         items.insert("foo".to_string(), json!({"login": {"password": "v"}}));
@@ -477,7 +559,8 @@ mod tests {
         std::env::set_var("BITWARDEN_CLIENT_ID", "id");
         std::env::set_var("BITWARDEN_CLIENT_SECRET", "sec");
         std::env::set_var("BITWARDEN_MASTER_PASSWORD", "pw");
-        let src = BitwardenSource::with_cli(BitwardenSourceConfig::default(), mock, None);
+        let creds = BitwardenCredentials::from_env();
+        let src = BitwardenSource::with_cli(BitwardenSourceConfig::default(), mock, creds);
         let secrets = vec![ManifestSecret {
             name: "FOO".into(),
             item: Some("foo".into()),
@@ -507,7 +590,10 @@ mod tests {
         let src = BitwardenSource::with_cli(
             BitwardenSourceConfig::default(),
             mock,
-            Some("ABCDEF".into()),
+            BitwardenCredentials {
+                session: Some("ABCDEF".into()),
+                ..Default::default()
+            },
         );
         let secrets = vec![ManifestSecret {
             name: "FOO".into(),

--- a/src/sync_manifest.rs
+++ b/src/sync_manifest.rs
@@ -7,8 +7,9 @@ use std::env;
 use std::fs;
 use std::path::Path;
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 
+use crate::credentials::{ResolvedCredentials, StoredCredentials};
 use crate::destinations::{
     Destination, DestinationEntry, DestinationReport, DestinationRequest, EnvFileDestination,
     GitHubDestination,
@@ -16,7 +17,8 @@ use crate::destinations::{
 use crate::manifest::{
     value_hash, ManifestDestination, ManifestSource, RepoManifest, SyncState, DEFAULT_STATE_FILE,
 };
-use crate::sources::{BitwardenSource, SecretSource, StaticSource};
+use crate::paths::Paths;
+use crate::sources::{BitwardenCredentials, BitwardenSource, SecretSource, StaticSource};
 
 /// Test-only override: if set, points at a JSON file `{ "NAME": "value", ... }`
 /// that is used as a static source in place of the manifest's configured one.
@@ -55,13 +57,33 @@ pub fn sync_manifest(
         None => default_state_path(manifest_path),
     };
     let mut state = SyncState::load_or_default(&state_path)?;
-    let source = resolve_source(&manifest.source)?;
-    let report = run(&manifest, &mut state, source.as_ref(), manifest_path)?;
+    // Resolve credentials once: process env (which the caller has already
+    // populated from `.env`/`.env.local`) layered over the stored config file.
+    let stored = load_stored_credentials()?;
+    let resolved = ResolvedCredentials::resolve(&stored);
+    let source = resolve_source(&manifest.source, &resolved.bitwarden)?;
+    let report = run(
+        &manifest,
+        &mut state,
+        source.as_ref(),
+        &resolved,
+        manifest_path,
+    )?;
     state.save(&state_path)?;
     Ok(report)
 }
 
-fn resolve_source(source: &ManifestSource) -> Result<Box<dyn SecretSource>> {
+/// Load the stored credential config from the resolved config root. Honors
+/// `GH_SECRETS_HOME` (so tests stay isolated) just like the profile config.
+fn load_stored_credentials() -> Result<StoredCredentials> {
+    let paths = Paths::resolve()?;
+    StoredCredentials::load(&paths.credentials_file())
+}
+
+fn resolve_source(
+    source: &ManifestSource,
+    bitwarden: &BitwardenCredentials,
+) -> Result<Box<dyn SecretSource>> {
     if let Ok(path) = env::var(TEST_SOURCE_FILE_ENV) {
         let bytes = fs::read(&path).with_context(|| format!("reading test source file {path}"))?;
         let values: HashMap<String, String> = serde_json::from_slice(&bytes)
@@ -69,7 +91,10 @@ fn resolve_source(source: &ManifestSource) -> Result<Box<dyn SecretSource>> {
         return Ok(Box::new(StaticSource { values }));
     }
     match source {
-        ManifestSource::Bitwarden(cfg) => Ok(Box::new(BitwardenSource::new(cfg.clone()))),
+        ManifestSource::Bitwarden(cfg) => Ok(Box::new(BitwardenSource::with_credentials(
+            cfg.clone(),
+            bitwarden.clone(),
+        ))),
     }
 }
 
@@ -87,7 +112,12 @@ pub fn sync_manifest_with_source(
         None => default_state_path(manifest_path),
     };
     let mut state = SyncState::load_or_default(&state_path)?;
-    let report = run(&manifest, &mut state, source, manifest_path)?;
+    // A caller-supplied source still pushes to manifest destinations, so the
+    // GitHub destination needs a resolved token. This helper exists for tests,
+    // so resolve from the environment only (no config-file read) to stay
+    // hermetic; Bitwarden creds are unused because the source is provided.
+    let resolved = ResolvedCredentials::resolve(&StoredCredentials::default());
+    let report = run(&manifest, &mut state, source, &resolved, manifest_path)?;
     state.save(&state_path)?;
     Ok(report)
 }
@@ -96,6 +126,7 @@ fn run(
     manifest: &RepoManifest,
     state: &mut SyncState,
     source: &dyn SecretSource,
+    resolved: &ResolvedCredentials,
     manifest_path: &Path,
 ) -> Result<ManifestSyncReport> {
     let base_dir = manifest_path
@@ -123,7 +154,15 @@ fn run(
     let mut report = ManifestSyncReport::default();
     for dest_cfg in &manifest.destinations {
         let mut destination: Box<dyn Destination> = match dest_cfg {
-            ManifestDestination::Github(c) => Box::new(GitHubDestination::from_config(c)?),
+            ManifestDestination::Github(c) => {
+                let token = resolved.github_token.as_deref().ok_or_else(|| {
+                    anyhow!(
+                        "no GitHub token for destination github:{}: set GH_TOKEN/GITHUB_TOKEN (e.g. in .env) or run `gh-secrets auth github <token>`",
+                        c.repository
+                    )
+                })?;
+                Box::new(GitHubDestination::from_config(c, token)?)
+            }
             ManifestDestination::EnvFile(c) => {
                 Box::new(EnvFileDestination::from_config(c, base_dir))
             }

--- a/tests/e2e_auth.rs
+++ b/tests/e2e_auth.rs
@@ -1,0 +1,328 @@
+//! End-to-end tests for credential auth: the `gh-secrets auth` command group
+//! and the resolution precedence `shell env > .env > .env.local > config file`.
+//!
+//! Drives the compiled binary the way a user does. Two things are proven:
+//! 1. `auth status` reports where each credential resolves from — and never
+//!    prints the value itself.
+//! 2. The precedence actually selects the right GitHub token for a real
+//!    `manifest sync`: the token that reaches the (wiremock) GitHub API is the
+//!    one the precedence rules say should win.
+
+mod common;
+
+use std::fs;
+use std::sync::{Arc, Mutex};
+
+use assert_cmd::Command;
+use predicates::prelude::PredicateBooleanExt;
+use predicates::str::contains;
+use serde_json::json;
+use tempfile::TempDir;
+use wiremock::matchers::{method, path_regex};
+use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+
+/// Working dir holds `.env`/`.env.local`/manifest/source; `home/` is the
+/// isolated config root (so `auth` writes a tempdir credentials.json, never the
+/// developer's real one). `auth_headers` records the `Authorization` header of
+/// every GitHub request so a test can assert which token actually won.
+struct AuthHarness {
+    dir: TempDir,
+    server: MockServer,
+    auth_headers: Arc<Mutex<Vec<String>>>,
+}
+
+impl AuthHarness {
+    async fn new() -> Self {
+        let dir = TempDir::new().expect("tempdir");
+        let server = MockServer::start().await;
+        Self {
+            dir,
+            server,
+            auth_headers: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    /// A command with an isolated config root. Deliberately does NOT set
+    /// `GH_TOKEN`/`GITHUB_TOKEN` so each test controls the environment layer
+    /// explicitly. `current_dir` is the working dir so dotenv auto-load sees
+    /// the files we write there.
+    fn cmd(&self) -> Command {
+        let mut c = Command::cargo_bin("gh-secrets").expect("locate gh-secrets bin");
+        c.current_dir(self.dir.path())
+            .env("GH_SECRETS_HOME", self.dir.path().join("home"))
+            .env("GH_SECRETS_API_BASE", self.server.uri())
+            // Scrub any inherited credentials so the test starts from a known
+            // state regardless of the developer's shell / .env.
+            .env_remove("GH_TOKEN")
+            .env_remove("GITHUB_TOKEN")
+            .env_remove("BW_CLIENTID")
+            .env_remove("BITWARDEN_CLIENT_ID")
+            .env_remove("BW_CLIENTSECRET")
+            .env_remove("BITWARDEN_CLIENT_SECRET")
+            .env_remove("BW_PASSWORD")
+            .env_remove("BITWARDEN_MASTER_PASSWORD")
+            .env_remove("BITWARDEN_PASSWORD")
+            .env_remove("BW_SESSION")
+            .env_remove("BITWARDEN_SESSION");
+        c
+    }
+
+    fn write_file(&self, name: &str, contents: &str) {
+        fs::write(self.dir.path().join(name), contents).unwrap();
+    }
+
+    fn credentials_file(&self) -> std::path::PathBuf {
+        self.dir.path().join("home").join("credentials.json")
+    }
+
+    /// Mount a GitHub mock that accepts any token and records the bearer used.
+    async fn mount_github(&self, repo: &str) {
+        let pubkey = common::fake_pubkey_b64();
+        Mock::given(method("GET"))
+            .and(path_regex(format!(
+                "^/repos/{repo}/actions/secrets/public-key$"
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "key_id": "kid-1",
+                "key": pubkey,
+            })))
+            .mount(&self.server)
+            .await;
+
+        let headers = self.auth_headers.clone();
+        Mock::given(method("PUT"))
+            .and(path_regex(format!("^/repos/{repo}/actions/secrets/(.+)$")))
+            .respond_with(move |req: &Request| {
+                let auth = req
+                    .headers
+                    .get("authorization")
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or_default()
+                    .to_string();
+                headers.lock().unwrap().push(auth);
+                ResponseTemplate::new(201)
+            })
+            .mount(&self.server)
+            .await;
+    }
+
+    fn write_github_manifest(&self, repo: &str) {
+        self.write_file(
+            "gh-secrets.json",
+            &serde_json::to_string_pretty(&json!({
+                "source": {"type": "bitwarden"},
+                "secrets": [{"name": "FOO"}],
+                "destinations": [{"type": "github", "repository": repo}],
+            }))
+            .unwrap(),
+        );
+        self.write_file(
+            "source.json",
+            &serde_json::to_string_pretty(&json!({"FOO": "foo-value"})).unwrap(),
+        );
+    }
+
+    /// A `manifest sync` command wired to the static-source override so it never
+    /// contacts Bitwarden; only the GitHub token resolution is under test.
+    fn sync_cmd(&self) -> Command {
+        let mut c = self.cmd();
+        c.env(
+            "GH_SECRETS_TEST_SOURCE_FILE",
+            self.dir.path().join("source.json"),
+        )
+        .args(["manifest", "sync"]);
+        c
+    }
+
+    fn bearer_tokens(&self) -> Vec<String> {
+        self.auth_headers.lock().unwrap().clone()
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_auth_status_reports_unset_then_stored() {
+    let h = AuthHarness::new().await;
+
+    // Nothing configured anywhere.
+    h.cmd()
+        .args(["auth", "status"])
+        .assert()
+        .success()
+        .stdout(contains("GitHub token: not set"))
+        .stdout(contains("Bitwarden master password: not set"));
+
+    // Store a token; status now reports it as coming from stored config and the
+    // value itself is never printed.
+    h.cmd()
+        .args(["auth", "github", "ghp_supersecret_value"])
+        .assert()
+        .success()
+        .stdout(contains("stored GitHub token"));
+
+    h.cmd()
+        .args(["auth", "status"])
+        .assert()
+        .success()
+        .stdout(contains("GitHub token: set (from stored config)"))
+        .stdout(contains("ghp_supersecret_value").not());
+
+    // On Unix the stored file is owner-only.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = fs::metadata(h.credentials_file())
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o777, 0o600);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_auth_bitwarden_stores_only_selected_fields() {
+    let h = AuthHarness::new().await;
+    h.cmd()
+        .args(["auth", "bitwarden", "--client-id", "user.abc"])
+        .assert()
+        .success()
+        .stdout(contains("stored Bitwarden client id"));
+
+    h.cmd()
+        .args(["auth", "status"])
+        .assert()
+        .success()
+        .stdout(contains("Bitwarden client id: set (from stored config)"))
+        .stdout(contains("Bitwarden client secret: not set"))
+        .stdout(contains("user.abc").not());
+
+    // No flags at all is a usage error.
+    h.cmd()
+        .args(["auth", "bitwarden"])
+        .assert()
+        .failure()
+        .stderr(contains("provide at least one"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_auth_status_provenance_follows_precedence() {
+    let h = AuthHarness::new().await;
+    // Stored config has a token...
+    h.cmd()
+        .args(["auth", "github", "from_config"])
+        .assert()
+        .success();
+    // ...and .env also defines one: .env must win over config.
+    h.write_file(".env", "GH_TOKEN=from_dotenv\n");
+    h.cmd()
+        .args(["auth", "status"])
+        .assert()
+        .success()
+        .stdout(contains("GitHub token: set (from the .env file)"));
+
+    // A real shell variable outranks .env.
+    h.cmd()
+        .env("GH_TOKEN", "from_shell")
+        .args(["auth", "status"])
+        .assert()
+        .success()
+        .stdout(contains("GitHub token: set (from your shell environment)"));
+
+    // .env.local is the lowest of the file layers: it only shows through for a
+    // key that .env doesn't define.
+    h.write_file(".env", "OTHER=1\n");
+    h.write_file(".env.local", "GH_TOKEN=from_local\n");
+    h.cmd()
+        .args(["auth", "status"])
+        .assert()
+        .success()
+        .stdout(contains("GitHub token: set (from the .env.local file)"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_manifest_sync_uses_stored_github_token() {
+    let h = AuthHarness::new().await;
+    let repo = "owner/repo1";
+    h.write_github_manifest(repo);
+    h.mount_github(repo).await;
+
+    // No token in env or .env — only the stored config has one.
+    h.cmd()
+        .args(["auth", "github", "ghp_from_stored_config"])
+        .assert()
+        .success();
+    h.sync_cmd().assert().success().stdout(contains("created"));
+
+    let bearers = h.bearer_tokens();
+    assert_eq!(bearers.len(), 1, "expected exactly one PUT");
+    assert_eq!(bearers[0], "Bearer ghp_from_stored_config");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_manifest_sync_dotenv_token_beats_stored_config() {
+    let h = AuthHarness::new().await;
+    let repo = "owner/repo1";
+    h.write_github_manifest(repo);
+    h.mount_github(repo).await;
+
+    // Stored config has one token, .env has another — .env must win.
+    h.cmd()
+        .args(["auth", "github", "ghp_stored_loser"])
+        .assert()
+        .success();
+    h.write_file(".env", "GH_TOKEN=ghp_dotenv_winner\n");
+
+    h.sync_cmd().assert().success().stdout(contains("created"));
+
+    let bearers = h.bearer_tokens();
+    assert_eq!(bearers.len(), 1);
+    assert_eq!(bearers[0], "Bearer ghp_dotenv_winner");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_manifest_sync_shell_env_token_beats_dotenv() {
+    let h = AuthHarness::new().await;
+    let repo = "owner/repo1";
+    h.write_github_manifest(repo);
+    h.mount_github(repo).await;
+
+    h.write_file(".env", "GH_TOKEN=ghp_dotenv_loser\n");
+    let mut cmd = h.sync_cmd();
+    cmd.env("GH_TOKEN", "ghp_shell_winner");
+    cmd.assert().success().stdout(contains("created"));
+
+    let bearers = h.bearer_tokens();
+    assert_eq!(bearers.len(), 1);
+    assert_eq!(bearers[0], "Bearer ghp_shell_winner");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_auth_clear_removes_stored_credentials() {
+    let h = AuthHarness::new().await;
+    h.cmd().args(["auth", "github", "ghp_x"]).assert().success();
+    h.cmd()
+        .args(["auth", "bitwarden", "--client-id", "user.x"])
+        .assert()
+        .success();
+    assert!(h.credentials_file().exists());
+
+    // Clearing only the GitHub token leaves Bitwarden intact and keeps the file.
+    h.cmd()
+        .args(["auth", "clear", "--github"])
+        .assert()
+        .success();
+    h.cmd()
+        .args(["auth", "status"])
+        .assert()
+        .success()
+        .stdout(contains("GitHub token: not set"))
+        .stdout(contains("Bitwarden client id: set (from stored config)"));
+
+    // Clearing everything removes the file entirely.
+    h.cmd().args(["auth", "clear"]).assert().success();
+    assert!(!h.credentials_file().exists());
+    h.cmd()
+        .args(["auth", "status"])
+        .assert()
+        .success()
+        .stdout(contains("Bitwarden client id: not set"));
+}


### PR DESCRIPTION
## What

Makes the manifest flow easy to authenticate. The GitHub token *and* the Bitwarden login now resolve through one precedence:

```
shell env  >  .env  >  .env.local  >  stored config
```

- **`manifest sync`** and **`auth status`** auto-load `.env` then `.env.local` from the working directory into the process environment, setting only keys that aren't already present (so a real shell var wins, then `.env`, then `.env.local`).
- A new profile-independent **`<root>/credentials.json`** (`0600` on Unix) is the lowest tier, managed by a new command group:
  - `gh-secrets auth github <token>`
  - `gh-secrets auth bitwarden [--client-id|--client-secret|--master-password]`
  - `gh-secrets auth status` — reports where each credential resolves from, **never prints a value**
  - `gh-secrets auth clear [--github|--bitwarden]`

## Why scoped, not global

Dotenv auto-load runs only for the credential-consuming commands, not every invocation. The profile flow keeps its token in its own config and never reads these vars, and a *global* load would pull a developer's real `.env` into unrelated test subprocesses — the test suites run with the repo root (which holds a real `.env`) as CWD.

## Design notes

- Because the dotenv layers collapse into the process env, the existing env-reading logic (`env_first`, `github_token_from_env`) gets the top three tiers for free; this PR only adds the `> stored config` tail and threads resolved credentials into the Bitwarden source / GitHub destination.
- `BW_SESSION`/`BITWARDEN_SESSION` is intentionally never read from stored config — it's an ephemeral unlock token. Whatever tier supplies a Bitwarden value, the `bw` subprocess still receives it under the canonical `BW_*` name.

## Tests

- Unit: dotenv precedence planner (`src/envfile.rs`), env→stored merge (`src/credentials.rs`, `src/sources.rs`).
- E2E (`tests/e2e_auth.rs`, wired into the default gate): `auth status` provenance without leaking values; `credentials.json` round-trip + `0600`; and the key assertion — a real `manifest sync` against a wiremock GitHub records the exact `Authorization` bearer, so each precedence case confirms the token that *won* is the one that actually reached the API.
- Verified the dotenv parser against the real repo `.env`: `auth status` correctly reports each credential as "from the .env file" with no values printed.

Full gate green locally (`just check`: 38 unit + 28 e2e + fmt + clippy `-D warnings`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)