### PR TITLE
fix(install): abort on Intel macOS instead of 404 on a missing asset

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,8 +222,10 @@ Allowed types: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`,
   "release PR" carrying the next `Cargo.toml`/`Cargo.lock` version bump and the
   generated `CHANGELOG.md`. **Merging that release PR** is the release action:
   it tags `vX.Y.Z`, cuts the GitHub Release, and the same workflow run then
-  builds binaries for x86_64 + aarch64 Linux/macOS and x86_64 Windows, attaches
-  each archive with a SHA-256 checksum, and (if `CARGO_REGISTRY_TOKEN` is
+  builds binaries for x86_64 + aarch64 Linux, aarch64 macOS, and x86_64 Windows
+  (x86_64 macOS is intentionally omitted — see the matrix comment in
+  `release.yml`), attaches each archive with a SHA-256 checksum, and (if
+  `CARGO_REGISTRY_TOKEN` is
   configured) publishes to crates.io.
 - release-please opens its release PR from the branch
   `release-please--branches--master--components--gh-secrets`, *not* the plain
@@ -244,10 +246,12 @@ Allowed types: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`,
   ```
   Without the secret, the `live-e2e` job in `.github/workflows/ci.yml` is a
   no-op. Rotate the PAT through the same command whenever needed.
-- `scripts/install.sh` is the cross-platform installer (Linux/macOS x86_64 +
-  arm64, Windows x86_64 under a POSIX shell): it detects the host target,
+- `scripts/install.sh` is the cross-platform installer (Linux x86_64 + arm64,
+  macOS arm64, Windows x86_64 under a POSIX shell): it detects the host target,
   downloads the matching release archive, verifies its SHA-256, and installs
-  the binary. It must stay in lock-step with the release asset naming in
+  the binary. Hosts with no published asset (Intel macOS, non-x86_64 Windows)
+  abort with a `cargo install` suggestion rather than 404 on a missing archive,
+  so the installer's target set must track the `release.yml` matrix. It must stay in lock-step with the release asset naming in
   `release.yml` — the archive is `gh-secrets-<tag>-<target>.<ext>` and the
   checksum asset is that name with `.sha256` *appended* (it keeps the
   `.tar.gz`/`.zip`), and the binary sits under a leading

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -13,7 +13,7 @@
 # Equivalent environment variables: GH_SECRETS_VERSION, GH_SECRETS_INSTALL_DIR.
 # Set GITHUB_TOKEN to lift the GitHub API rate limit when resolving "latest".
 #
-# Covers Linux and macOS (x86_64, arm64) and Windows x86_64 under a POSIX shell
+# Covers Linux (x86_64, arm64), macOS (arm64), and Windows x86_64 under a POSIX shell
 # (Git Bash / MSYS / WSL). For native Windows PowerShell or unpublished targets,
 # use `cargo install gh-secrets --locked`.
 #
@@ -68,6 +68,12 @@ detect_target() {
     # The release matrix publishes Windows for x86_64 only.
     if [ "$ext" = "zip" ] && [ "$arch_part" != "x86_64" ]; then
         err "no prebuilt Windows binary for $arch; install with 'cargo install $BIN --locked'"
+    fi
+
+    # The release matrix publishes macOS for aarch64 only: Apple Silicon runs
+    # it natively, and there is no prebuilt Intel binary (see release.yml).
+    if [ "$os_part" = "apple-darwin" ] && [ "$arch_part" != "aarch64" ]; then
+        err "no prebuilt macOS binary for $arch; install with 'cargo install $BIN --locked'"
     fi
 
     TARGET="${arch_part}-${os_part}"


### PR DESCRIPTION
While tidying the build-target docs I found a real lock-step gap: the release matrix intentionally omits `x86_64-apple-darwin` (see `release.yml` — macos-13 runner allocation is unreliable; Apple Silicon runs the aarch64 binary natively), but `scripts/install.sh` had no guard for that case. On an Intel Mac it would build `TARGET=x86_64-apple-darwin` and 404 on an asset that's never published — while the parallel Windows-on-ARM case *was* already guarded.

**Fix:**
- `install.sh`: add the missing macOS guard, mirroring the existing Windows one — Intel macOS now aborts with `install with 'cargo install gh-secrets --locked'` instead of a confusing download failure. Verified `Darwin/x86_64` aborts and `Darwin/arm64` still resolves to `aarch64-apple-darwin`.
- Docs: correct `AGENTS.md` to describe the actual published targets (x86_64 + aarch64 Linux, aarch64 macOS, x86_64 Windows) and note that hosts without a published asset abort cleanly, so the installer's target set must track the matrix.

No change to the release matrix itself — the omission is deliberate and documented.

https://claude.ai/code/session_01HiGi5RrVTZzsuFD4c8umzg

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiGi5RrVTZzsuFD4c8umzg)_