### PR TITLE
ci: open release-please PRs under a PAT so they can auto-merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,14 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          # Use a PAT so the release PR is opened by a real user, not the
+          # GITHUB_TOKEN bot. PRs opened by GITHUB_TOKEN do NOT trigger the
+          # `pull_request` CI/lint workflows, so their required checks never
+          # run and auto-merge can never fire. A PAT-opened PR triggers CI like
+          # any other, so auto-merge works. Falls back to GITHUB_TOKEN when the
+          # secret is unset (release PR then still works, but must be merged
+          # manually). See "Releases and CI secrets" in AGENTS.md.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
   build:
     name: build (${{ matrix.target }})

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,9 +235,26 @@ Allowed types: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`,
   name). Watch for that exact branch name if you poll for the release PR.
 - The release build is chained off release-please's `release_created` output in
   the **same** workflow on purpose: a tag pushed by the default `GITHUB_TOKEN`
-  does not trigger a separate `push: tags` workflow, so a single workflow with
-  no extra PAT is the robust design. `release-please-manifest.json` is the
-  source of truth for the current version — keep it equal to `Cargo.toml`.
+  does not trigger a separate `push: tags` workflow, so a single workflow is the
+  robust design — the build chaining itself needs no PAT (the `RELEASE_PLEASE_TOKEN`
+  below is a separate concern, only so the release *PR* gets CI).
+  `release-please-manifest.json` is the source of truth for the current version
+  — keep it equal to `Cargo.toml`.
+- The release PR opens under a PAT (`RELEASE_PLEASE_TOKEN`) when that repo secret
+  is set, falling back to `GITHUB_TOKEN` otherwise. This matters because a PR
+  opened by `GITHUB_TOKEN` does **not** trigger the `pull_request` CI/lint
+  workflows — GitHub suppresses that to avoid recursive runs — so its required
+  status checks never appear and **auto-merge can never fire**; the release PR
+  has to be merged by hand. A PAT-opened PR triggers CI like any human PR, so
+  branch protection is satisfied and auto-merge works. Set it with a PAT (a
+  fine-grained token with `contents: read/write` + `pull-requests: read/write`
+  on this repo, or a classic `repo` PAT):
+  ```
+  gh secret set RELEASE_PLEASE_TOKEN --repo <owner>/<repo>
+  # paste the token when prompted
+  ```
+  Without it nothing breaks — the workflow falls back to `GITHUB_TOKEN` and the
+  release PR is merged manually (squash, like any release PR).
 - Live e2e in CI is gated on a `GH_E2E_TOKEN` repo secret. Set it with a PAT
   that has `repo` scope on the account that should host the sandbox repo:
   ```


### PR DESCRIPTION
Release-please opens its release PR with the default `GITHUB_TOKEN`, and PRs opened by `GITHUB_TOKEN` don't trigger the `pull_request` CI/lint workflows (GitHub suppresses that to avoid recursive runs). So the release PR's required checks never appear, it sits `blocked`, and **auto-merge can never fire** — every release has to be merged by hand (as v0.1.1 #18 and v0.1.2 #21 both were).

**Fix:** pass a PAT to the action via `token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}`. A PAT-opened PR triggers CI like any human PR, so branch protection is satisfied and auto-merge works.

- **Graceful fallback:** if `RELEASE_PLEASE_TOKEN` isn't set, it falls back to `GITHUB_TOKEN` — current behavior, nothing breaks (release PR just needs a manual merge).
- **`AGENTS.md`:** documents the secret, why it's needed, and the `gh secret set` command; scopes the existing "no extra PAT" note (that referred to the build chaining, which still needs no PAT).

**One manual step on your side to activate it:** create the PAT and add the secret —
```
gh secret set RELEASE_PLEASE_TOKEN --repo nickderobertis/github-secrets
```
A fine-grained token with `contents: read/write` + `pull-requests: read/write` on this repo (or a classic `repo` PAT) works. Until then, the fallback keeps everything functioning exactly as today.

https://claude.ai/code/session_01HiGi5RrVTZzsuFD4c8umzg

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiGi5RrVTZzsuFD4c8umzg)_