### PR TITLE
feat: list available secrets in the CLI (profile and manifest)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,7 +9,7 @@ use crate::credentials::StoredCredentials;
 use crate::destinations::{DestinationReport, GITHUB_TOKEN_ENVS};
 use crate::envfile;
 use crate::github::GitHubClient;
-use crate::manifest::{RepoManifest, DEFAULT_MANIFEST_FILE};
+use crate::manifest::{ManifestSource, RepoManifest, DEFAULT_MANIFEST_FILE};
 use crate::paths::Paths;
 use crate::secrets::Upsert;
 use crate::sources::{BW_CLIENTID_ENVS, BW_CLIENTSECRET_ENVS, BW_PASSWORD_ENVS, BW_SESSION_ENVS};
@@ -116,6 +116,13 @@ enum ManifestCmd {
         /// Where to write the manifest. Defaults to `./gh-secrets.json`.
         #[arg(long, short)]
         path: Option<PathBuf>,
+    },
+    /// List the secrets the manifest manages (names and their source mapping),
+    /// without contacting the source or printing any value.
+    List {
+        /// Path to the manifest file. Defaults to `./gh-secrets.json`.
+        #[arg(long, short)]
+        config: Option<PathBuf>,
     },
     /// Pull every managed secret from the manifest's source and push to each
     /// destination that doesn't already hold the current value.
@@ -379,6 +386,13 @@ pub fn run() -> Result<()> {
                 RepoManifest::starter().save(&target)?;
                 println!("manifest: wrote starter to {}", target.display());
             }
+            ManifestCmd::List { config } => {
+                let manifest_path = config.unwrap_or_else(|| PathBuf::from(DEFAULT_MANIFEST_FILE));
+                let manifest = RepoManifest::load(&manifest_path).with_context(|| {
+                    format!("loading manifest from {}", manifest_path.display())
+                })?;
+                list_manifest_secrets(&manifest);
+            }
             ManifestCmd::Sync { config, state } => {
                 // Make `.env`/`.env.local` in the working directory available as
                 // credentials before resolving the source/destinations.
@@ -535,6 +549,36 @@ fn print_secret_group(label: &str, names: &[String]) {
     println!("{label} ({}):", names.len());
     for name in names {
         println!("  - {name}");
+    }
+}
+
+/// Print the secrets a manifest manages and where each is sourced from. Reads
+/// only the checked-in manifest — no source contact, no credentials — and the
+/// manifest holds only name/item/field mapping, never a value.
+fn list_manifest_secrets(manifest: &RepoManifest) {
+    let (source_label, default_field) = match &manifest.source {
+        // Mirror `BitwardenSource::default_field`: unspecified means `password`.
+        ManifestSource::Bitwarden(c) => (
+            "bitwarden",
+            c.default_field.as_deref().unwrap_or("password"),
+        ),
+    };
+    if manifest.secrets.is_empty() {
+        println!("manifest: no secrets declared (source: {source_label})");
+        return;
+    }
+    println!(
+        "manifest secrets ({}, source: {source_label}):",
+        manifest.secrets.len()
+    );
+    for s in &manifest.secrets {
+        let field = s.field.as_deref().unwrap_or(default_field);
+        println!(
+            "  - {}  ({source_label} item '{}', field '{}')",
+            s.name,
+            s.source_item(),
+            field
+        );
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -174,6 +174,11 @@ enum SecretCmd {
         name: String,
         repository: Option<String>,
     },
+    /// List secret names (never values), globally and per-repository.
+    List {
+        /// Optional repository; if omitted, lists global and every per-repo override.
+        repository: Option<String>,
+    },
     /// Push changed secrets to GitHub.
     Sync {
         /// Optional secret name; if omitted, syncs every defined secret.
@@ -328,6 +333,9 @@ pub fn run() -> Result<()> {
                     scope_label(repository.as_deref())
                 );
             }
+            SecretCmd::List { repository } => {
+                list_secrets(&profile, repository.as_deref());
+            }
             SecretCmd::Sync {
                 name,
                 repository,
@@ -467,6 +475,66 @@ fn scope_label(repo: Option<&str>) -> String {
     match repo {
         Some(r) => format!("repo '{r}'"),
         None => "global".to_string(),
+    }
+}
+
+/// Print the names of stored secrets, never their values. With `repository`
+/// set, only that repo's per-repo overrides are listed; otherwise the global
+/// secrets and every per-repo override are shown, each group sorted by name.
+fn list_secrets(profile: &ProfileConfig, repository: Option<&str>) {
+    let sorted = |names: Vec<&str>| -> Vec<String> {
+        let mut v: Vec<String> = names.into_iter().map(str::to_string).collect();
+        v.sort();
+        v
+    };
+
+    if let Some(repo) = repository {
+        let names = sorted(profile.repository_secrets.names_for(repo));
+        if names.is_empty() {
+            println!("secrets: none defined for {}", scope_label(Some(repo)));
+            return;
+        }
+        print_secret_group(&scope_label(Some(repo)), &names);
+        return;
+    }
+
+    let global = sorted(
+        profile
+            .global_secrets
+            .secrets
+            .iter()
+            .map(|s| s.name.as_str())
+            .collect(),
+    );
+    let per_repo: Vec<(&String, Vec<String>)> = profile
+        .repository_secrets
+        .by_repo
+        .iter()
+        .filter(|(_, secrets)| !secrets.is_empty())
+        .map(|(repo, secrets)| {
+            (
+                repo,
+                sorted(secrets.iter().map(|s| s.name.as_str()).collect()),
+            )
+        })
+        .collect();
+
+    if global.is_empty() && per_repo.is_empty() {
+        println!("secrets: none defined");
+        return;
+    }
+    if !global.is_empty() {
+        print_secret_group("global", &global);
+    }
+    for (repo, names) in &per_repo {
+        print_secret_group(&scope_label(Some(repo)), names);
+    }
+}
+
+fn print_secret_group(label: &str, names: &[String]) {
+    println!("{label} ({}):", names.len());
+    for name in names {
+        println!("  - {name}");
     }
 }
 

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -16,6 +16,7 @@ mod common;
 use base64::engine::general_purpose::STANDARD as B64;
 use base64::Engine;
 use common::{fake_pubkey_b64, E2eHarness};
+use predicates::prelude::PredicateBooleanExt;
 use predicates::str::contains;
 use serde_json::{json, Value};
 use wiremock::matchers::{header, method, path_regex};
@@ -78,6 +79,70 @@ async fn e2e_local_state_persists_across_invocations() {
         .assert()
         .failure()
         .stderr(contains("was not defined"));
+}
+
+/// `secrets list` shows global and per-repo secret names, sorted, and never
+/// prints a value — the listing exists precisely to let a user audit what's
+/// defined without exposing the values.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_secrets_list_shows_names_not_values() {
+    let h = E2eHarness::new().await;
+
+    // Empty profile reports nothing defined.
+    h.cmd()
+        .args(["secrets", "list"])
+        .assert()
+        .success()
+        .stdout(contains("none defined"));
+
+    h.cmd()
+        .args(["secrets", "add", "DB_PASS", "pass-value"])
+        .assert()
+        .success();
+    h.cmd()
+        .args(["secrets", "add", "API_KEY", "key-value"])
+        .assert()
+        .success();
+    h.cmd()
+        .args([
+            "secrets",
+            "add",
+            "DEPLOY_KEY",
+            "deploy-value",
+            "owner/repo1",
+        ])
+        .assert()
+        .success();
+
+    // Default listing: globals + per-repo overrides, names only, no values.
+    h.cmd()
+        .args(["secrets", "list"])
+        .assert()
+        .success()
+        .stdout(contains("global (2):"))
+        .stdout(contains("API_KEY"))
+        .stdout(contains("DB_PASS"))
+        .stdout(contains("repo 'owner/repo1' (1):"))
+        .stdout(contains("DEPLOY_KEY"))
+        .stdout(contains("key-value").not())
+        .stdout(contains("pass-value").not())
+        .stdout(contains("deploy-value").not());
+
+    // Scoped to a repo: only that repo's overrides.
+    h.cmd()
+        .args(["secrets", "list", "owner/repo1"])
+        .assert()
+        .success()
+        .stdout(contains("repo 'owner/repo1' (1):"))
+        .stdout(contains("DEPLOY_KEY"))
+        .stdout(contains("API_KEY").not());
+
+    // A repo with no overrides says so explicitly.
+    h.cmd()
+        .args(["secrets", "list", "owner/repo2"])
+        .assert()
+        .success()
+        .stdout(contains("none defined for repo 'owner/repo2'"));
 }
 
 /// Happy path: push a global secret to two repos, then re-sync and confirm it

--- a/tests/e2e_manifest.rs
+++ b/tests/e2e_manifest.rs
@@ -153,6 +153,53 @@ async fn e2e_manifest_init_writes_starter() {
         .stderr(contains("refusing to overwrite"));
 }
 
+/// `manifest list` reports the managed secret names and their Bitwarden source
+/// mapping by reading only the checked-in manifest — no source contact, no
+/// credentials, and (since the manifest holds no values) nothing sensitive.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_manifest_list_shows_declared_secrets() {
+    let h = ManifestHarness::new().await;
+    h.write_manifest(&json!({
+        "source": {"type": "bitwarden", "default_field": "api-key"},
+        "secrets": [
+            {"name": "FOO", "item": "foo-bw-item"},
+            {"name": "BAR", "field": "password"}
+        ],
+        "destinations": [
+            {"type": "env_file", "path": ".env"}
+        ]
+    }));
+
+    h.cmd()
+        .args(["manifest", "list"])
+        .assert()
+        .success()
+        .stdout(contains("manifest secrets (2, source: bitwarden):"))
+        // FOO: explicit item, inherits the source's default field.
+        .stdout(contains(
+            "FOO  (bitwarden item 'foo-bw-item', field 'api-key')",
+        ))
+        // BAR: item defaults to the secret name, explicit field overrides.
+        .stdout(contains("BAR  (bitwarden item 'BAR', field 'password')"));
+}
+
+/// A manifest with no declared secrets lists cleanly rather than erroring.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_manifest_list_handles_empty_secrets() {
+    let h = ManifestHarness::new().await;
+    h.write_manifest(&json!({
+        "source": {"type": "bitwarden"},
+        "secrets": [],
+        "destinations": []
+    }));
+
+    h.cmd()
+        .args(["manifest", "list"])
+        .assert()
+        .success()
+        .stdout(contains("no secrets declared"));
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn e2e_manifest_sync_pushes_to_github_and_env_file() {
     let h = ManifestHarness::new().await;


### PR DESCRIPTION
## What

Adds a way to list the secrets the CLI knows about, covering **both** workflows, without ever printing a value.

### `gh-secrets secrets list [repository]` (profile flow)
Lists the global and per-repository secret names stored in the active profile.

```
$ gh-secrets secrets list
global (2):
  - API_KEY
  - DB_PASS
repo 'owner/repo1' (1):
  - DEPLOY_KEY
```

- No values, ever — only names + scope.
- Default view shows global secrets plus every per-repo override, each group sorted by name.
- `secrets list <repo>` scopes to that repo's overrides; empty scopes report `secrets: none defined[ for repo '<repo>']`.

### `gh-secrets manifest list [-c <path>]` (manifest / Bitwarden flow)
Lists the secrets a checked-in `gh-secrets.json` manages, with each name's resolved Bitwarden source mapping.

```
$ gh-secrets manifest list
manifest secrets (2, source: bitwarden):
  - FOO  (bitwarden item 'foo-bw-item', field 'api-key')
  - BAR  (bitwarden item 'BAR', field 'password')
```

- Reads only the checked-in manifest — no source contact, no credentials.
- The manifest holds only name/item/field mapping, so nothing sensitive is printed. The item/field resolution mirrors `BitwardenSource` exactly (item defaults to the secret name; field defaults to the source's `default_field`, else `password`).

## Why

The profile and manifest flows had no way to audit *what* secrets are defined without inspecting JSON on disk. Listing names (never values) is symmetric with the rest of the command surface and upholds the never-print-a-value invariant.

## Tests

Extends the e2e suites and the full `just check` gate passes (fmt, clippy `-D warnings`, all unit/integration/e2e):
- `e2e.rs`: `secrets list` shows global + per-repo names, sorted, and asserts stored values never appear in stdout.
- `e2e_manifest.rs`: `manifest list` shows declared secrets with their item/field mapping (including default-field inheritance), plus an empty-manifest case.

https://claude.ai/code/session_011dAjcaxjHGMXEfnwRrjLsy

---
_Generated by [Claude Code](https://claude.ai/code/session_011dAjcaxjHGMXEfnwRrjLsy)_