### PR TITLE
feat: add `source list` to enumerate a manifest's Bitwarden vault

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,15 +16,26 @@ secrets in bulk. It has two distinct workflows:
    the user keeps a local config of profiles, included/excluded repositories,
    and global + per-repository secret values; `gh-secrets secrets sync` then
    pushes only the secrets that have changed since the last sync.
+   `gh-secrets secrets list [repo]` reports stored secret names (global +
+   per-repo), never values.
 
-2. **Manifest-based** (`gh-secrets manifest init|sync`): a repo-local
-   `gh-secrets.json` declares an external `source` (today: Bitwarden) and one
-   or more `destinations` (today: GitHub Actions secrets, dotenv file).
-   `gh-secrets manifest sync` pulls every managed secret from the source and
-   pushes to each destination that doesn't already hold the current value.
-   Idempotent across runs via a co-located `.gh-secrets-state.json`
-   (gitignore it) that stores per-(secret, destination) SHA-256 hashes — the
-   plaintext value is never persisted there.
+2. **Manifest-based** (`gh-secrets manifest init|list|sync`,
+   `gh-secrets source list`): a repo-local `gh-secrets.json` declares an
+   external `source` (today: Bitwarden) and one or more `destinations` (today:
+   GitHub Actions secrets, dotenv file). `gh-secrets manifest sync` pulls every
+   managed secret from the source and pushes to each destination that doesn't
+   already hold the current value. Idempotent across runs via a co-located
+   `.gh-secrets-state.json` (gitignore it) that stores per-(secret,
+   destination) SHA-256 hashes — the plaintext value is never persisted there.
+   `gh-secrets manifest list` reports the secrets the manifest *declares* (each
+   name plus its resolved source item/field), reading only the checked-in file.
+   `gh-secrets source list` instead *enumerates the source itself* — it unlocks
+   the configured source (e.g. the Bitwarden vault, scoped by the manifest's
+   collection/organization) and prints every available item's name and id, so a
+   user can discover which item names exist to wire into the manifest. Both
+   honor the never-print-a-value invariant: `manifest list` reads only mapping
+   metadata, and `source list` requests item *identity* only, never field
+   values.
 
 ## Command surface
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,7 +12,9 @@ use crate::github::GitHubClient;
 use crate::manifest::{ManifestSource, RepoManifest, DEFAULT_MANIFEST_FILE};
 use crate::paths::Paths;
 use crate::secrets::Upsert;
-use crate::sources::{BW_CLIENTID_ENVS, BW_CLIENTSECRET_ENVS, BW_PASSWORD_ENVS, BW_SESSION_ENVS};
+use crate::sources::{
+    SourceItem, BW_CLIENTID_ENVS, BW_CLIENTSECRET_ENVS, BW_PASSWORD_ENVS, BW_SESSION_ENVS,
+};
 use crate::sync::{self, SyncReport};
 use crate::sync_manifest::{self, ManifestSyncReport};
 
@@ -62,6 +64,13 @@ enum Command {
     Manifest {
         #[command(subcommand)]
         command: ManifestCmd,
+    },
+    /// Inspect the external source a manifest pulls from (e.g. the Bitwarden
+    /// vault): discover which item names are available to reference. Reads the
+    /// manifest's source config and unlocks the source; never prints a value.
+    Source {
+        #[command(subcommand)]
+        command: SourceCmd,
     },
     /// Store credentials for the manifest flow (GitHub token, Bitwarden login)
     /// as the lowest-priority fallback. Resolution order is: shell env > .env >
@@ -134,6 +143,18 @@ enum ManifestCmd {
         /// next to the manifest.
         #[arg(long)]
         state: Option<PathBuf>,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum SourceCmd {
+    /// List the items available in the manifest's source (e.g. every entry in
+    /// the Bitwarden vault, scoped by the manifest's collection/organization).
+    /// Prints each item's name and id — never a value.
+    List {
+        /// Path to the manifest file. Defaults to `./gh-secrets.json`.
+        #[arg(long, short)]
+        config: Option<PathBuf>,
     },
 }
 
@@ -403,6 +424,17 @@ pub fn run() -> Result<()> {
             }
         },
 
+        Command::Source { command } => match command {
+            SourceCmd::List { config } => {
+                // Same credential resolution as `manifest sync`: load
+                // `.env`/`.env.local` before unlocking the source.
+                envfile::load_dotenv_cwd();
+                let manifest_path = config.unwrap_or_else(|| PathBuf::from(DEFAULT_MANIFEST_FILE));
+                let items = sync_manifest::list_source_items(&manifest_path)?;
+                print_source_items(&items);
+            }
+        },
+
         Command::Auth { command } => {
             let creds_path = paths.credentials_file();
             let mut stored = StoredCredentials::load(&creds_path)?;
@@ -579,6 +611,21 @@ fn list_manifest_secrets(manifest: &RepoManifest) {
             s.source_item(),
             field
         );
+    }
+}
+
+/// Print the items available in a manifest's source (name + id), sorted by name
+/// for stable output. Identity metadata only — never a value.
+fn print_source_items(items: &[SourceItem]) {
+    if items.is_empty() {
+        println!("source: no items available");
+        return;
+    }
+    let mut sorted: Vec<&SourceItem> = items.iter().collect();
+    sorted.sort_by(|a, b| a.name.cmp(&b.name).then_with(|| a.id.cmp(&b.id)));
+    println!("source items ({}):", sorted.len());
+    for item in sorted {
+        println!("  - {}  ({})", item.name, item.id);
     }
 }
 

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -24,10 +24,25 @@ pub struct FetchedSecret {
     pub value: String,
 }
 
+/// Identity metadata for one item available in a source. Carries no secret
+/// value — only what a user needs to discover an item and reference it from a
+/// manifest (its display name and stable id).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceItem {
+    pub name: String,
+    pub id: String,
+}
+
 /// Anything that can hand the orchestrator the current values for a list of
 /// manifest secrets.
 pub trait SecretSource {
     fn fetch(&self, secrets: &[ManifestSecret]) -> Result<Vec<FetchedSecret>>;
+
+    /// Enumerate the items available in the source (e.g. every entry in the
+    /// Bitwarden vault, optionally scoped by the source config). Returns
+    /// identity metadata only — never a secret value — so callers can discover
+    /// which item names exist to wire into a manifest.
+    fn list_available(&self) -> Result<Vec<SourceItem>>;
 }
 
 /// In-memory source used by tests and (eventually) by a `manifest dry-run`
@@ -67,6 +82,18 @@ impl SecretSource for StaticSource {
             });
         }
         Ok(out)
+    }
+
+    fn list_available(&self) -> Result<Vec<SourceItem>> {
+        // No real ids in a static map, so the key doubles as name and id.
+        Ok(self
+            .values
+            .keys()
+            .map(|k| SourceItem {
+                name: k.clone(),
+                id: k.clone(),
+            })
+            .collect())
     }
 }
 
@@ -154,6 +181,23 @@ pub trait BwCli {
     fn unlock(&self, password: &str) -> Result<String>;
     fn sync(&self, session: &str) -> Result<()>;
     fn get_item(&self, session: &str, identifier: &str) -> Result<Value>;
+    /// Enumerate items in the vault, optionally scoped to a collection and/or
+    /// organization. Returns identity metadata only (`name`, `id`).
+    fn list_items(
+        &self,
+        session: &str,
+        collection_id: Option<&str>,
+        organization_id: Option<&str>,
+    ) -> Result<Vec<SourceItem>>;
+}
+
+/// Minimal projection of a `bw list items` element: every Bitwarden item has a
+/// stable `id` and a display `name`; we ignore the rest (including any value
+/// fields) so nothing sensitive is deserialized here.
+#[derive(Debug, Deserialize)]
+struct BwListItem {
+    id: String,
+    name: String,
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
@@ -249,6 +293,32 @@ impl BwCli for RealBwCli {
         Self::expect_success(&args, &out)?;
         serde_json::from_slice(&out.stdout)
             .with_context(|| format!("parsing `bw get item {identifier}` JSON"))
+    }
+
+    fn list_items(
+        &self,
+        session: &str,
+        collection_id: Option<&str>,
+        organization_id: Option<&str>,
+    ) -> Result<Vec<SourceItem>> {
+        let mut args: Vec<&str> = vec!["list", "items"];
+        if let Some(cid) = collection_id {
+            args.extend_from_slice(&["--collectionid", cid]);
+        }
+        if let Some(oid) = organization_id {
+            args.extend_from_slice(&["--organizationid", oid]);
+        }
+        let out = Self::run(&args, &[(BW_SESSION_ENV, session)])?;
+        Self::expect_success(&args, &out)?;
+        let items: Vec<BwListItem> =
+            serde_json::from_slice(&out.stdout).context("parsing `bw list items` JSON")?;
+        Ok(items
+            .into_iter()
+            .map(|i| SourceItem {
+                name: i.name,
+                id: i.id,
+            })
+            .collect())
     }
 }
 
@@ -351,6 +421,15 @@ impl<C: BwCli> SecretSource for BitwardenSource<C> {
         }
         Ok(out)
     }
+
+    fn list_available(&self) -> Result<Vec<SourceItem>> {
+        let session = self.ensure_session()?;
+        self.cli.list_items(
+            &session,
+            self.config.collection_id.as_deref(),
+            self.config.organization_id.as_deref(),
+        )
+    }
 }
 
 /// Pulls a field out of a Bitwarden item's JSON.
@@ -441,6 +520,7 @@ mod tests {
     struct MockBw {
         status: BwStatus,
         items: HashMap<String, Value>,
+        listed: Vec<SourceItem>,
         calls: RefCell<Vec<String>>,
     }
 
@@ -470,6 +550,19 @@ mod tests {
                 .cloned()
                 .ok_or_else(|| anyhow!("no mock item '{identifier}'"))
         }
+        fn list_items(
+            &self,
+            _session: &str,
+            collection_id: Option<&str>,
+            organization_id: Option<&str>,
+        ) -> Result<Vec<SourceItem>> {
+            self.calls.borrow_mut().push(format!(
+                "list_items:{}:{}",
+                collection_id.unwrap_or("-"),
+                organization_id.unwrap_or("-")
+            ));
+            Ok(self.listed.clone())
+        }
     }
 
     #[test]
@@ -479,6 +572,7 @@ mod tests {
         let mock = MockBw {
             status: BwStatus::Unauthenticated,
             items,
+            listed: Vec::new(),
             calls: RefCell::new(Vec::new()),
         };
         std::env::set_var(BW_CLIENTID_ENV, "id");
@@ -549,6 +643,7 @@ mod tests {
         let mock = MockBw {
             status: BwStatus::Unauthenticated,
             items,
+            listed: Vec::new(),
             calls: RefCell::new(Vec::new()),
         };
         // Only the BITWARDEN_* aliases are set; the native BW_* names are unset.
@@ -585,6 +680,7 @@ mod tests {
         let mock = MockBw {
             status: BwStatus::Unlocked,
             items,
+            listed: Vec::new(),
             calls: RefCell::new(Vec::new()),
         };
         let src = BitwardenSource::with_cli(
@@ -605,5 +701,64 @@ mod tests {
         let calls = src.cli.calls.borrow().clone();
         // No status/login/unlock/sync — straight to get_item.
         assert_eq!(calls, vec!["get_item:foo"]);
+    }
+
+    #[test]
+    fn bitwarden_source_lists_available_items_with_scope() {
+        let mock = MockBw {
+            status: BwStatus::Unlocked,
+            items: HashMap::new(),
+            listed: vec![
+                SourceItem {
+                    name: "Stripe API".into(),
+                    id: "id-1".into(),
+                },
+                SourceItem {
+                    name: "GitHub PAT".into(),
+                    id: "id-2".into(),
+                },
+            ],
+            calls: RefCell::new(Vec::new()),
+        };
+        let config = BitwardenSourceConfig {
+            collection_id: Some("coll-1".into()),
+            organization_id: Some("org-1".into()),
+            default_field: None,
+        };
+        let src = BitwardenSource::with_cli(
+            config,
+            mock,
+            BitwardenCredentials {
+                session: Some("S".into()),
+                ..Default::default()
+            },
+        );
+        let got = src.list_available().unwrap();
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].name, "Stripe API");
+        assert_eq!(got[0].id, "id-1");
+        // Session short-circuits auth; the collection/org scope is forwarded.
+        let calls = src.cli.calls.borrow().clone();
+        assert_eq!(calls, vec!["list_items:coll-1:org-1"]);
+    }
+
+    #[test]
+    fn static_source_lists_its_keys_as_items() {
+        let src = StaticSource::new([("FOO", "v1"), ("BAR", "v2")]);
+        let mut got = src.list_available().unwrap();
+        got.sort_by(|a, b| a.name.cmp(&b.name));
+        assert_eq!(
+            got,
+            vec![
+                SourceItem {
+                    name: "BAR".into(),
+                    id: "BAR".into()
+                },
+                SourceItem {
+                    name: "FOO".into(),
+                    id: "FOO".into()
+                },
+            ]
+        );
     }
 }

--- a/src/sync_manifest.rs
+++ b/src/sync_manifest.rs
@@ -18,7 +18,9 @@ use crate::manifest::{
     value_hash, ManifestDestination, ManifestSource, RepoManifest, SyncState, DEFAULT_STATE_FILE,
 };
 use crate::paths::Paths;
-use crate::sources::{BitwardenCredentials, BitwardenSource, SecretSource, StaticSource};
+use crate::sources::{
+    BitwardenCredentials, BitwardenSource, SecretSource, SourceItem, StaticSource,
+};
 
 /// Test-only override: if set, points at a JSON file `{ "NAME": "value", ... }`
 /// that is used as a static source in place of the manifest's configured one.
@@ -71,6 +73,20 @@ pub fn sync_manifest(
     )?;
     state.save(&state_path)?;
     Ok(report)
+}
+
+/// Enumerate the items available in the manifest's source (e.g. the Bitwarden
+/// vault, scoped by the manifest's collection/organization), so a user can
+/// discover which item names exist to reference from `gh-secrets.json`. Reads
+/// only identity metadata — never a secret value. Resolves credentials the same
+/// way `sync_manifest` does (env over stored config), and unlocks the source.
+pub fn list_source_items(manifest_path: &Path) -> Result<Vec<SourceItem>> {
+    let manifest = RepoManifest::load(manifest_path)
+        .with_context(|| format!("loading manifest from {}", manifest_path.display()))?;
+    let stored = load_stored_credentials()?;
+    let resolved = ResolvedCredentials::resolve(&stored);
+    let source = resolve_source(&manifest.source, &resolved.bitwarden)?;
+    source.list_available()
 }
 
 /// Load the stored credential config from the resolved config root. Honors

--- a/tests/e2e_manifest.rs
+++ b/tests/e2e_manifest.rs
@@ -31,6 +31,7 @@ use assert_cmd::Command;
 use base64::engine::general_purpose::STANDARD as B64;
 use base64::Engine;
 use common::fake_pubkey_b64;
+use predicates::prelude::PredicateBooleanExt;
 use predicates::str::contains;
 use serde_json::{json, Value};
 use tempfile::TempDir;
@@ -181,6 +182,40 @@ async fn e2e_manifest_list_shows_declared_secrets() {
         ))
         // BAR: item defaults to the secret name, explicit field overrides.
         .stdout(contains("BAR  (bitwarden item 'BAR', field 'password')"));
+}
+
+/// `source list` enumerates the items *available in the source* (here the
+/// static test source standing in for the Bitwarden vault) — distinct from
+/// `manifest list`, which only echoes what the manifest already declares. It
+/// prints each item's name and id and never leaks a value.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_source_list_enumerates_available_items() {
+    let h = ManifestHarness::new().await;
+    // The manifest declares only FOO, but the source/vault holds more — the
+    // whole point of `source list` is to surface the ones you haven't wired up.
+    h.write_manifest(&json!({
+        "source": {"type": "bitwarden"},
+        "secrets": [{"name": "FOO"}],
+        "destinations": [{"type": "env_file", "path": ".env"}]
+    }));
+    h.write_source(&json!({
+        "FOO": "foo-secret",
+        "STRIPE_KEY": "stripe-secret",
+        "DB_PASSWORD": "db-secret"
+    }));
+
+    h.cmd()
+        .args(["source", "list"])
+        .assert()
+        .success()
+        .stdout(contains("source items (3):"))
+        .stdout(contains("STRIPE_KEY"))
+        .stdout(contains("DB_PASSWORD"))
+        .stdout(contains("FOO"))
+        // Never the values.
+        .stdout(contains("foo-secret").not())
+        .stdout(contains("stripe-secret").not())
+        .stdout(contains("db-secret").not());
 }
 
 /// A manifest with no declared secrets lists cleanly rather than erroring.


### PR DESCRIPTION
## What

Adds **`gh-secrets source list`** — a command that *enumerates the manifest's source itself* (the Bitwarden vault), as opposed to the existing `manifest list` which only echoes what a manifest already declares.

```
$ gh-secrets source list
source items (3):
  - DB password        (a1b2c3d4-...)
  - GitHub PAT         (e5f6a7b8-...)
  - Stripe API key     (c9d0e1f2-...)
```

- Unlocks the configured source (same credential resolution as `manifest sync`: `.env`/`.env.local` → stored config) and runs `bw list items`, scoped by the manifest's `collection_id`/`organization_id` if set.
- Prints each item's **name and id only** — identity metadata, never a field value.

## Why

`manifest list` / `secrets list` (v0.2.0) list *declared* entries. But Bitwarden vault items often have names that don't match your secret names, so there was no way to discover what's actually available to reference — you had to guess item names and trial-sync. `source list` closes that gap: enumerate the vault, copy the item name/id into your manifest's `item:` field.

## How

- Extends the source abstraction with `SecretSource::list_available()` and `BwCli::list_items()` (shells out to `bw list items --collectionid/--organizationid`, deserializing only `id`+`name`).
- The static test source (`GH_SECRETS_TEST_SOURCE_FILE`) enumerates its keys, so the e2e suite exercises `source list` end-to-end without contacting Bitwarden.
- New top-level `source` command group, keeping vault-enumeration cleanly separate from the file-reading `manifest list`.

## Tests

Full `just check` passes (fmt, clippy `-D warnings`, 40 unit + 33 e2e):
- Unit: `bitwarden_source_lists_available_items_with_scope` (asserts session reuse + collection/org forwarding), `static_source_lists_its_keys_as_items`.
- e2e: `e2e_source_list_enumerates_available_items` — vault has more items than the manifest declares; asserts all surface and no values leak.

`AGENTS.md` updated to document the new command surface (`manifest init|list|sync`, `source list`).

https://claude.ai/code/session_011dAjcaxjHGMXEfnwRrjLsy

---
_Generated by [Claude Code](https://claude.ai/code/session_011dAjcaxjHGMXEfnwRrjLsy)_