### PR TITLE
feat: map source secret to differently-named/multiple destination names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,8 +27,19 @@ secrets in bulk. It has two distinct workflows:
    already hold the current value. Idempotent across runs via a co-located
    `.gh-secrets-state.json` (gitignore it) that stores per-(secret,
    destination) SHA-256 hashes — the plaintext value is never persisted there.
-   `gh-secrets manifest list` reports the secrets the manifest *declares* (each
-   name plus its resolved source item/field), reading only the checked-in file.
+   Each managed secret has a *source-side* identity (`name`, plus an optional
+   `item`/`field` to look up a differently-named source entry) and a
+   *destination-side* identity (`destination_names`). When `destination_names`
+   is omitted it defaults to `[name]` — the common "same name everywhere" case
+   needs no extra config. Supplying it lets the destination name differ from the
+   source identity and lets one source value fan out to several destination
+   names (e.g. a single publish token pushed as both `NPM_TOKEN` and
+   `NODE_AUTH_TOKEN`); the value is fetched once and pushed under each name, and
+   each (destination-name, destination) pair tracks its own hash in the state
+   file. `gh-secrets manifest list` reports the secrets the manifest *declares*
+   (each name plus its resolved source item/field, and the fan-out arrow `->
+   NAME, NAME` when `destination_names` is set), reading only the checked-in
+   file.
    `gh-secrets source list` instead *enumerates the source itself* — it unlocks
    the configured source (e.g. the Bitwarden vault, scoped by the manifest's
    collection/organization) and prints every available item's name and id, so a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,10 @@ secrets in bulk. It has two distinct workflows:
    names (e.g. a single publish token pushed as both `NPM_TOKEN` and
    `NODE_AUTH_TOKEN`); the value is fetched once and pushed under each name, and
    each (destination-name, destination) pair tracks its own hash in the state
-   file. `gh-secrets manifest list` reports the secrets the manifest *declares*
+   file. Destination names must be unique across the whole manifest —
+   `RepoManifest::load` rejects a config where two managed secrets resolve to the
+   same destination name (which would otherwise race to last-writer-wins), so the
+   error surfaces at load time before any source contact. `gh-secrets manifest list` reports the secrets the manifest *declares*
    (each name plus its resolved source item/field, and the fan-out arrow `->
    NAME, NAME` when `destination_names` is set), reading only the checked-in
    file.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -605,12 +605,24 @@ fn list_manifest_secrets(manifest: &RepoManifest) {
     );
     for s in &manifest.secrets {
         let field = s.field.as_deref().unwrap_or(default_field);
-        println!(
-            "  - {}  ({source_label} item '{}', field '{}')",
-            s.name,
-            s.source_item(),
-            field
-        );
+        if s.destination_names.is_empty() {
+            println!(
+                "  - {}  ({source_label} item '{}', field '{}')",
+                s.name,
+                s.source_item(),
+                field
+            );
+        } else {
+            // The value fans out to one or more destination names that differ
+            // from the source-side identity; show the mapping explicitly.
+            println!(
+                "  - {}  ({source_label} item '{}', field '{}') -> {}",
+                s.name,
+                s.source_item(),
+                field,
+                s.destination_names.join(", ")
+            );
+        }
     }
 }
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -19,9 +19,19 @@ use sha2::{Digest, Sha256};
 pub const DEFAULT_MANIFEST_FILE: &str = "gh-secrets.json";
 pub const DEFAULT_STATE_FILE: &str = ".gh-secrets-state.json";
 
-/// One secret managed by the manifest. `item` defaults to `name` when omitted
-/// (i.e. the source's identifier matches the secret name). `field` defaults to
-/// the source's own default (typically `password` for Bitwarden logins).
+/// One secret managed by the manifest.
+///
+/// `name` is the secret's identity on the *source* side: it's the lookup key
+/// for the source (unless `item` overrides it) and the key the sync state hashes
+/// against. `field` defaults to the source's own default (typically `password`
+/// for Bitwarden logins).
+///
+/// `destination_names` is the identity on the *destination* side: the names this
+/// value is written under at every destination. When omitted it defaults to
+/// `[name]`, so the common "same name everywhere" case stays a single `name`.
+/// Supplying it lets the destination name differ from the source identity, and
+/// lets one source value fan out to several destination names (e.g. a single
+/// publish token written as both `NPM_TOKEN` and `NODE_AUTH_TOKEN`).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ManifestSecret {
     pub name: String,
@@ -29,12 +39,25 @@ pub struct ManifestSecret {
     pub item: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub field: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub destination_names: Vec<String>,
 }
 
 impl ManifestSecret {
     /// The identifier passed to the source for lookup.
     pub fn source_item(&self) -> &str {
         self.item.as_deref().unwrap_or(&self.name)
+    }
+
+    /// The names this value is written under at each destination. Defaults to
+    /// `[name]` when `destination_names` is omitted, so a secret that keeps the
+    /// same name everywhere needs no extra config.
+    pub fn dest_names(&self) -> Vec<&str> {
+        if self.destination_names.is_empty() {
+            vec![self.name.as_str()]
+        } else {
+            self.destination_names.iter().map(String::as_str).collect()
+        }
     }
 }
 
@@ -110,6 +133,7 @@ impl RepoManifest {
                 name: "EXAMPLE_SECRET".into(),
                 item: Some("example-bitwarden-item-name-or-id".into()),
                 field: None,
+                destination_names: Vec::new(),
             }],
             destinations: vec![
                 ManifestDestination::Github(GithubDestinationConfig {
@@ -253,14 +277,54 @@ mod tests {
             name: "FOO".into(),
             item: None,
             field: None,
+            destination_names: Vec::new(),
         };
         assert_eq!(s.source_item(), "FOO");
         let s2 = ManifestSecret {
             name: "FOO".into(),
             item: Some("foo-bw".into()),
             field: None,
+            destination_names: Vec::new(),
         };
         assert_eq!(s2.source_item(), "foo-bw");
+    }
+
+    #[test]
+    fn dest_names_defaults_to_name_then_uses_overrides() {
+        // Omitted: the secret keeps its single source-side name on the
+        // destination too.
+        let single = ManifestSecret {
+            name: "FOO".into(),
+            item: None,
+            field: None,
+            destination_names: Vec::new(),
+        };
+        assert_eq!(single.dest_names(), vec!["FOO"]);
+
+        // Supplied: the value fans out to every listed destination name, which
+        // can differ entirely from the source-side `name`.
+        let fanned = ManifestSecret {
+            name: "npm-publish-token".into(),
+            item: None,
+            field: None,
+            destination_names: vec!["NPM_TOKEN".into(), "NODE_AUTH_TOKEN".into()],
+        };
+        assert_eq!(fanned.dest_names(), vec!["NPM_TOKEN", "NODE_AUTH_TOKEN"]);
+    }
+
+    #[test]
+    fn destination_names_omitted_from_json_when_empty() {
+        let s = ManifestSecret {
+            name: "FOO".into(),
+            item: None,
+            field: None,
+            destination_names: Vec::new(),
+        };
+        let json = serde_json::to_string(&s).unwrap();
+        assert!(!json.contains("destination_names"), "got: {json}");
+        // And it round-trips back to an empty list (defaulted).
+        let back: ManifestSecret = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.destination_names, Vec::<String>::new());
     }
 
     #[test]

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -12,7 +12,7 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -148,7 +148,39 @@ impl RepoManifest {
 
     pub fn load(path: &Path) -> Result<Self> {
         let bytes = fs::read(path).with_context(|| format!("reading {}", path.display()))?;
-        serde_json::from_slice(&bytes).with_context(|| format!("parsing {}", path.display()))
+        let manifest: Self = serde_json::from_slice(&bytes)
+            .with_context(|| format!("parsing {}", path.display()))?;
+        manifest
+            .validate()
+            .with_context(|| format!("validating {}", path.display()))?;
+        Ok(manifest)
+    }
+
+    /// Reject a config that can't sync coherently. Today's only rule: every
+    /// resolved destination name must be unique across the whole manifest. Two
+    /// managed secrets fanning out to the same destination name would race to
+    /// last-writer-wins at every destination and thrash the state file, so we
+    /// surface it as a config error instead of silently picking one.
+    pub fn validate(&self) -> Result<()> {
+        let mut owner: BTreeMap<&str, &str> = BTreeMap::new();
+        for secret in &self.secrets {
+            for dest in secret.dest_names() {
+                match owner.insert(dest, secret.name.as_str()) {
+                    None => {}
+                    Some(prev) if prev == secret.name => bail!(
+                        "destination name '{dest}' is listed more than once for secret '{}'; \
+                         each destination name must be unique",
+                        secret.name
+                    ),
+                    Some(prev) => bail!(
+                        "destination name '{dest}' is claimed by two managed secrets ('{prev}' \
+                         and '{}'); each destination name must be unique",
+                        secret.name
+                    ),
+                }
+            }
+        }
+        Ok(())
     }
 
     pub fn save(&self, path: &Path) -> Result<()> {
@@ -310,6 +342,49 @@ mod tests {
             destination_names: vec!["NPM_TOKEN".into(), "NODE_AUTH_TOKEN".into()],
         };
         assert_eq!(fanned.dest_names(), vec!["NPM_TOKEN", "NODE_AUTH_TOKEN"]);
+    }
+
+    fn secret(name: &str, dest_names: &[&str]) -> ManifestSecret {
+        ManifestSecret {
+            name: name.into(),
+            item: None,
+            field: None,
+            destination_names: dest_names.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    fn manifest_with(secrets: Vec<ManifestSecret>) -> RepoManifest {
+        RepoManifest {
+            source: ManifestSource::Bitwarden(BitwardenSourceConfig::default()),
+            secrets,
+            destinations: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn validate_accepts_distinct_destination_names() {
+        let m = manifest_with(vec![
+            secret("A", &[]),
+            secret("npm", &["NPM_TOKEN", "NODE_AUTH_TOKEN"]),
+        ]);
+        assert!(m.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_collision_across_secrets() {
+        // Two secrets resolve to the same destination name `SHARED`.
+        let m = manifest_with(vec![secret("SHARED", &[]), secret("other", &["SHARED"])]);
+        let err = m.validate().unwrap_err().to_string();
+        assert!(err.contains("destination name 'SHARED'"), "got: {err}");
+        assert!(err.contains("two managed secrets"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_rejects_duplicate_within_one_secret() {
+        let m = manifest_with(vec![secret("npm", &["NPM_TOKEN", "NPM_TOKEN"])]);
+        let err = m.validate().unwrap_err().to_string();
+        assert!(err.contains("destination name 'NPM_TOKEN'"), "got: {err}");
+        assert!(err.contains("listed more than once"), "got: {err}");
     }
 
     #[test]

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -585,6 +585,7 @@ mod tests {
             name: "STRIPE".into(),
             item: Some("stripe".into()),
             field: None,
+            destination_names: Vec::new(),
         }];
         let got = src.fetch(&secrets).unwrap();
         assert_eq!(got.len(), 1);
@@ -660,6 +661,7 @@ mod tests {
             name: "FOO".into(),
             item: Some("foo".into()),
             field: None,
+            destination_names: Vec::new(),
         }];
         let got = src.fetch(&secrets).unwrap();
         assert_eq!(got[0].value, "v");
@@ -695,6 +697,7 @@ mod tests {
             name: "FOO".into(),
             item: Some("foo".into()),
             field: None,
+            destination_names: Vec::new(),
         }];
         let got = src.fetch(&secrets).unwrap();
         assert_eq!(got[0].value, "v");

--- a/src/sync_manifest.rs
+++ b/src/sync_manifest.rs
@@ -153,18 +153,35 @@ fn run(
     let fetched = source
         .fetch(&manifest.secrets)
         .context("fetching from source")?;
+    // The source returns one value per managed secret, keyed by the secret's
+    // (source-side) `name`; index it so we can fan each value out to its
+    // destination names regardless of the order the source returned them in.
+    let fetched_by_name: HashMap<&str, &str> = fetched
+        .iter()
+        .map(|f| (f.name.as_str(), f.value.as_str()))
+        .collect();
 
-    // Compute current hashes once.
+    // Fan each managed secret out into one destination entry per destination
+    // name. The source hash is recorded once under the secret's `name`; each
+    // pushed entry hashes against its own destination name (so the same value
+    // written under two names tracks independently in the state file).
     let mut entries: Vec<DestinationEntry> = Vec::with_capacity(fetched.len());
-    for f in &fetched {
-        let h = value_hash(&f.name, &f.value);
-        state.record_source(&f.name, &h);
-        entries.push(DestinationEntry {
-            name: f.name.clone(),
-            value: f.value.clone(),
-            current_hash: h,
-            last_pushed_hash: None, // filled in per-destination below
-        });
+    for secret in &manifest.secrets {
+        let value = *fetched_by_name.get(secret.name.as_str()).ok_or_else(|| {
+            anyhow!(
+                "source returned no value for managed secret '{}'",
+                secret.name
+            )
+        })?;
+        state.record_source(&secret.name, &value_hash(&secret.name, value));
+        for dest_name in secret.dest_names() {
+            entries.push(DestinationEntry {
+                name: dest_name.to_string(),
+                value: value.to_string(),
+                current_hash: value_hash(dest_name, value),
+                last_pushed_hash: None, // filled in per-destination below
+            });
+        }
     }
 
     let mut report = ManifestSyncReport::default();
@@ -245,6 +262,7 @@ mod tests {
                 name: "FOO".into(),
                 item: None,
                 field: None,
+                destination_names: Vec::new(),
             }],
             destinations: vec![ManifestDestination::EnvFile(EnvFileDestinationConfig {
                 path: env_path,
@@ -273,6 +291,49 @@ mod tests {
         let report2 = sync_manifest_with_source(&manifest_path, None, &source).unwrap();
         assert!(report2.is_noop());
         assert_eq!(report2.destinations[0].report.unchanged, vec!["FOO"]);
+    }
+
+    #[test]
+    fn one_source_value_fans_out_to_multiple_destination_names() {
+        let dir = TempDir::new().unwrap();
+        // Source identity is `npm-token`; it must land under two GitHub-style
+        // names in the destination.
+        let manifest = RepoManifest {
+            source: ManifestSource::Bitwarden(BitwardenSourceConfig::default()),
+            secrets: vec![ManifestSecret {
+                name: "npm-token".into(),
+                item: None,
+                field: None,
+                destination_names: vec!["NPM_TOKEN".into(), "NODE_AUTH_TOKEN".into()],
+            }],
+            destinations: vec![ManifestDestination::EnvFile(EnvFileDestinationConfig {
+                path: PathBuf::from(".env"),
+            })],
+        };
+        let manifest_path = dir.path().join("gh-secrets.json");
+        manifest.save(&manifest_path).unwrap();
+
+        let source = StaticSource::new(vec![("npm-token", "s3cr3t")]);
+        let report = sync_manifest_with_source(&manifest_path, None, &source).unwrap();
+        // Both destination names are created from the single source value.
+        assert_eq!(
+            report.destinations[0].report.created,
+            vec!["NPM_TOKEN", "NODE_AUTH_TOKEN"]
+        );
+
+        let content = std::fs::read_to_string(dir.path().join(".env")).unwrap();
+        assert!(content.contains("NPM_TOKEN=\"s3cr3t\""));
+        assert!(content.contains("NODE_AUTH_TOKEN=\"s3cr3t\""));
+        // The source-side identity is never written as a destination key.
+        assert!(!content.contains("npm-token="));
+
+        // Re-running is a no-op for both fanned-out names.
+        let report2 = sync_manifest_with_source(&manifest_path, None, &source).unwrap();
+        assert!(report2.is_noop());
+        assert_eq!(
+            report2.destinations[0].report.unchanged,
+            vec!["NPM_TOKEN", "NODE_AUTH_TOKEN"]
+        );
     }
 
     #[test]

--- a/tests/e2e_manifest.rs
+++ b/tests/e2e_manifest.rs
@@ -346,6 +346,29 @@ async fn e2e_manifest_fans_one_source_value_out_to_multiple_names() {
     );
 }
 
+/// A manifest where two managed secrets resolve to the same destination name is
+/// a config error: it's caught at load time, so even a read-only `manifest list`
+/// refuses it (and `sync` never contacts the source).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_manifest_rejects_duplicate_destination_names() {
+    let h = ManifestHarness::new().await;
+    h.write_manifest(&json!({
+        "source": {"type": "bitwarden"},
+        "secrets": [
+            {"name": "primary", "destination_names": ["SHARED"]},
+            {"name": "other", "destination_names": ["SHARED"]}
+        ],
+        "destinations": [{"type": "env_file", "path": ".env"}]
+    }));
+
+    h.cmd()
+        .args(["manifest", "list"])
+        .assert()
+        .failure()
+        .stderr(contains("destination name 'SHARED'"))
+        .stderr(contains("two managed secrets"));
+}
+
 /// `manifest list` surfaces the source→destination fan-out mapping so a reader
 /// can see which names a value lands under without contacting the source.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/tests/e2e_manifest.rs
+++ b/tests/e2e_manifest.rs
@@ -284,6 +284,90 @@ async fn e2e_manifest_sync_pushes_to_github_and_env_file() {
     assert!(foo_dests["env_file:.env"].is_string());
 }
 
+/// One source value can be written under several destination names — and a
+/// destination name can differ entirely from the source-side identity. The
+/// single source item `npm-token` fans out to `NPM_TOKEN` + `NODE_AUTH_TOKEN`
+/// at both destinations; a resync is a no-op for all of them.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_manifest_fans_one_source_value_out_to_multiple_names() {
+    let h = ManifestHarness::new().await;
+    let repo = "owner/repo1";
+    h.write_manifest(&json!({
+        "source": {"type": "bitwarden"},
+        "secrets": [
+            {"name": "npm-token", "destination_names": ["NPM_TOKEN", "NODE_AUTH_TOKEN"]}
+        ],
+        "destinations": [
+            {"type": "github", "repository": repo},
+            {"type": "env_file", "path": ".env"}
+        ]
+    }));
+    // Source is keyed by the secret's (source-side) name.
+    h.write_source(&json!({"npm-token": "npm-value"}));
+    h.mount_github(repo).await;
+
+    h.cmd().args(["manifest", "sync"]).assert().success();
+
+    // GitHub: one PUT per destination name, each under the destination name and
+    // never the source-side identity.
+    {
+        let bodies = h.put_bodies.lock().unwrap();
+        let names: Vec<&str> = bodies.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(bodies.len(), 2, "got names: {names:?}");
+        assert!(names.contains(&"NPM_TOKEN"));
+        assert!(names.contains(&"NODE_AUTH_TOKEN"));
+        assert!(!names.contains(&"npm-token"));
+        // Plaintext never appears in any PUT body.
+        for (name, body) in bodies.iter() {
+            let serialized = serde_json::to_string(body).unwrap();
+            assert!(
+                !serialized.contains("npm-value"),
+                "plaintext leaked into PUT body for {name}"
+            );
+        }
+    }
+
+    // Env file: both destination names present, source identity is not a key.
+    let content = fs::read_to_string(h.env_file()).unwrap();
+    assert!(content.contains("NPM_TOKEN=\"npm-value\""));
+    assert!(content.contains("NODE_AUTH_TOKEN=\"npm-value\""));
+    assert!(!content.contains("npm-token="));
+
+    // Resync with the same source value is a complete no-op.
+    h.cmd()
+        .args(["manifest", "sync"])
+        .assert()
+        .success()
+        .stdout(contains("nothing to do"));
+    assert_eq!(
+        h.put_bodies.lock().unwrap().len(),
+        2,
+        "no new PUTs on the no-op resync"
+    );
+}
+
+/// `manifest list` surfaces the source→destination fan-out mapping so a reader
+/// can see which names a value lands under without contacting the source.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_manifest_list_shows_fan_out_mapping() {
+    let h = ManifestHarness::new().await;
+    h.write_manifest(&json!({
+        "source": {"type": "bitwarden"},
+        "secrets": [
+            {"name": "npm-token", "destination_names": ["NPM_TOKEN", "NODE_AUTH_TOKEN"]}
+        ],
+        "destinations": [{"type": "env_file", "path": ".env"}]
+    }));
+
+    h.cmd()
+        .args(["manifest", "list"])
+        .assert()
+        .success()
+        .stdout(contains(
+        "npm-token  (bitwarden item 'npm-token', field 'password') -> NPM_TOKEN, NODE_AUTH_TOKEN",
+    ));
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn e2e_manifest_resync_with_unchanged_source_is_a_noop() {
     let h = ManifestHarness::new().await;


### PR DESCRIPTION
## What & why

A manifest secret previously coupled its source-side identity and its destination name into one `name` (with `item` as the only source override). This adds a clean split so a secret can have **one name in the source and a different name — or several names — in the destination**.

- `name` (+ optional `item`/`field`) — source-side identity: lookup key and state-hash key.
- `destination_names` (new, optional) — destination-side identity: the names the fetched value is written under at every destination.

Omitting `destination_names` defaults it to `[name]`, so **every existing manifest is unchanged**. Supplying it covers both asks:

```json
{ "name": "npm-token", "destination_names": ["NPM_TOKEN", "NODE_AUTH_TOKEN"] }
```

This fetches the source item `npm-token` once and pushes it to GitHub and the env file under both `NPM_TOKEN` and `NODE_AUTH_TOKEN` (never under the source-side `npm-token`). A single rename is just a one-element list.

## Behavior details

- The value is fetched once per managed secret, then fanned out into one destination entry per destination name. Each entry hashes against its **own** name via the existing domain-separated `value_hash`, and state is keyed `(destination-name, destination)` — so each fanned-out name converges to a clean no-op on resync independently.
- `manifest list` shows the mapping with a `-> NAME, NAME` arrow when `destination_names` is set; output for plain secrets is unchanged.
- **Validation:** `RepoManifest::load` now rejects a config where two managed secrets resolve to the same destination name (or one secret lists a name twice). Such a config would race to last-writer-wins at every destination and thrash the state file, so it's surfaced as a load-time config error before any source contact — even read-only `manifest list` refuses it.

## Tests

Full `just check` is green (fmt, clippy `-D warnings`, 46 unit/integration, 36 e2e). New coverage:

- unit: `dest_names()` defaulting + override; empty `destination_names` omitted from JSON; orchestrator fan-out to multiple env names + no-op resync; `validate()` accepts distinct names and rejects cross-secret / within-secret collisions.
- e2e: `manifest sync` fan-out to GitHub + env file (one PUT per destination name, plaintext never leaks, no-op resync); `manifest list` shows the fan-out arrow; a duplicate-destination manifest fails with a clear error.

`AGENTS.md` documents the source-vs-destination identity split and the uniqueness rule.

https://claude.ai/code/session_01MHYp5R6KQXqG8Q2taTNSXv

---
_Generated by [Claude Code](https://claude.ai/code/session_01MHYp5R6KQXqG8Q2taTNSXv)_