### PR TITLE
test: add live Bitwarden e2e suite against an isolated account

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,16 +111,19 @@ jobs:
           just test-live
 
       # Bitwarden live e2e runs only when the isolated test account's api-key
-      # credentials are configured as repo secrets. Skipped (not failed) when
-      # they're absent, so forks and unconfigured repos stay green.
-      - name: Install Bitwarden CLI
-        if: ${{ secrets.GH_SECRETS_BW_E2E_CLIENT_ID != '' }}
-        run: npm install -g @bitwarden/cli
-
+      # credentials are configured as repo secrets. The guard lives in the run
+      # script (the `secrets` context is not allowed in a step `if:`), so it is
+      # skipped — not failed — when they're absent: forks and unconfigured repos
+      # stay green, and `bw` is installed only when there's something to run.
       - name: Live e2e (Bitwarden)
-        if: ${{ secrets.GH_SECRETS_BW_E2E_CLIENT_ID != '' }}
         env:
           GH_SECRETS_BW_E2E_CLIENT_ID: ${{ secrets.GH_SECRETS_BW_E2E_CLIENT_ID }}
           GH_SECRETS_BW_E2E_CLIENT_SECRET: ${{ secrets.GH_SECRETS_BW_E2E_CLIENT_SECRET }}
           GH_SECRETS_BW_E2E_PASSWORD: ${{ secrets.GH_SECRETS_BW_E2E_PASSWORD }}
-        run: just test-live-bitwarden
+        run: |
+          if [ -z "$GH_SECRETS_BW_E2E_CLIENT_ID" ]; then
+            echo "GH_SECRETS_BW_E2E_* not configured; skipping Bitwarden live e2e."
+            exit 0
+          fi
+          npm install -g @bitwarden/cli
+          just test-live-bitwarden

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,11 +110,38 @@ jobs:
           fi
           just test-live
 
-      # Bitwarden live e2e runs only when the isolated test account's api-key
-      # credentials are configured as repo secrets. The guard lives in the run
-      # script (the `secrets` context is not allowed in a step `if:`), so it is
-      # skipped — not failed — when they're absent: forks and unconfigured repos
-      # stay green, and `bw` is installed only when there's something to run.
+  # Live e2e against a real, isolated Bitwarden account. Kept a separate job (not
+  # a step in live-e2e) so it is an independent required check, decoupled from the
+  # GitHub live test. Runs only when the isolated account's api-key credentials
+  # are configured as repo secrets; the guard lives in the run script (the
+  # `secrets` context is not allowed in a job/step `if:`), so it is skipped — not
+  # failed — when they're absent, keeping forks and unconfigured repos green.
+  live-e2e-bitwarden:
+    needs: check
+    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install just
+        uses: extractions/setup-just@v2
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
+      - name: Cache Cargo registry + build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Bootstrap
+        run: just bootstrap
+
       - name: Live e2e (Bitwarden)
         env:
           GH_SECRETS_BW_E2E_CLIENT_ID: ${{ secrets.GH_SECRETS_BW_E2E_CLIENT_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,12 +100,27 @@ jobs:
       - name: Bootstrap
         run: just bootstrap
 
-      - name: Live e2e
+      - name: Live e2e (GitHub)
         env:
           GH_TOKEN: ${{ secrets.GH_E2E_TOKEN }}
         run: |
           if [ -z "$GH_TOKEN" ]; then
-            echo "GH_E2E_TOKEN not configured; skipping live e2e."
+            echo "GH_E2E_TOKEN not configured; skipping GitHub live e2e."
             exit 0
           fi
           just test-live
+
+      # Bitwarden live e2e runs only when the isolated test account's api-key
+      # credentials are configured as repo secrets. Skipped (not failed) when
+      # they're absent, so forks and unconfigured repos stay green.
+      - name: Install Bitwarden CLI
+        if: ${{ secrets.GH_SECRETS_BW_E2E_CLIENT_ID != '' }}
+        run: npm install -g @bitwarden/cli
+
+      - name: Live e2e (Bitwarden)
+        if: ${{ secrets.GH_SECRETS_BW_E2E_CLIENT_ID != '' }}
+        env:
+          GH_SECRETS_BW_E2E_CLIENT_ID: ${{ secrets.GH_SECRETS_BW_E2E_CLIENT_ID }}
+          GH_SECRETS_BW_E2E_CLIENT_SECRET: ${{ secrets.GH_SECRETS_BW_E2E_CLIENT_SECRET }}
+          GH_SECRETS_BW_E2E_PASSWORD: ${{ secrets.GH_SECRETS_BW_E2E_PASSWORD }}
+        run: just test-live-bitwarden

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,14 @@ Use the `just` recipes; do not hand-roll equivalent commands.
   API. Requires `GH_TOKEN` with `repo` scope; creates (idempotently) a private
   sandbox repo `gh-secrets-e2e-sandbox` on the authenticated user's account
   and cleans up the secrets it creates.
+- `just test-live-bitwarden` — opt-in: run the live e2e suite against a real,
+  isolated Bitwarden account (`tests/e2e_live_bitwarden.rs`). Requires the
+  account's api-key credentials in the environment (`GH_SECRETS_BW_E2E_CLIENT_ID`,
+  `GH_SECRETS_BW_E2E_CLIENT_SECRET`, `GH_SECRETS_BW_E2E_PASSWORD`) and the `bw`
+  CLI on PATH. Locally, wrap it with `scripts/bw-e2e-env.sh just
+  test-live-bitwarden`, which pulls those creds out of your own vault (see
+  "Releases and CI secrets"). Runs serially and self-cleans every item it
+  seeds; without the creds, every test skips.
 - `just lint` / `just format` — clippy / rustfmt.
 - `just upgrade` — `cargo update`, then re-run `just check`.
 
@@ -96,12 +104,14 @@ they exercise it the way a user does.
 - E2E is part of the default gate, not opt-in. The wiremock e2e suite
   (`tests/e2e.rs`) is plain `#[test]`-driven (no `#[ignore]`), spins up a
   mocked GitHub API with `wiremock`, and drives the compiled binary. Live
-  GitHub credentials are never required to run the gate. The live e2e suite
-  (`tests/e2e_live.rs`) exists alongside it for opt-in real-API coverage —
-  each test runtime-skips with a logged `skip:` line when
-  `GH_SECRETS_LIVE_TEST=1` is not set, so the default gate still compiles and
-  exercises that code path as a no-op (catching breakage in the live test
-  helpers without making any network call).
+  GitHub credentials are never required to run the gate. The live e2e suites
+  (`tests/e2e_live.rs` against GitHub, `tests/e2e_live_bitwarden.rs` against a
+  real isolated Bitwarden account) exist alongside it for opt-in real-API
+  coverage — each test runtime-skips with a logged `skip:` line when its gate
+  env vars are unset (`GH_SECRETS_LIVE_TEST=1` for both, plus the
+  `GH_SECRETS_BW_E2E_*` credentials for the Bitwarden suite), so the default
+  gate still compiles and exercises that code path as a no-op (catching
+  breakage in the live test helpers without making any network call).
 - The CLI never prints the value of a secret to stdout, stderr, log lines, or
   error messages. Secret values are also never written into the configured
   `GH_SECRETS_HOME` path other than inside the encrypted vault (`vault.json`),
@@ -246,6 +256,22 @@ Project-local layout and credentials:
   surfaces a 401 the user can act on, and undeclaring a secret does not delete
   it remotely. The sandbox repo is shared across tests; isolation comes from a
   per-test secret-name prefix and a `Drop` cleanup.
+- The live Bitwarden e2e suite (`tests/e2e_live_bitwarden.rs`) is the source
+  half's real-API complement: it drives `sync`/`source list` against a real,
+  *isolated* Bitwarden account (one that exists only for this test, so seeding
+  and deleting items in it is safe). It proves the auth chain the wiremock
+  suites can't — api-key login + master-password unlock + vault sync — then
+  pulls real values off real items through every field selector (`password`,
+  `#username`, `#notes`, `#fields.<NAME>`) to an env-file destination, asserts
+  a no-op resync, runs the full cold path through gh-secrets itself (login →
+  unlock → sync → fetch), and confirms a wrong master password yields a precise
+  unlock error with nothing written. Each test seeds uniquely-prefixed items
+  via `bw` directly (the product CLI is write-only-blocked for Bitwarden) and
+  deletes them in `Drop`. The hard-won isolation detail: every test points
+  `BITWARDENCLI_APPDATA_DIR` at its own tempdir, and gh-secrets' spawned `bw`
+  inherits it — so the suite never disturbs (or is confused by) a developer's
+  real Bitwarden login in the default app-data location. See
+  `tests/live_bw_common/mod.rs`.
 - The config-driven e2e suite (`tests/e2e_manifest.rs`) drives the binary
   through `init`, `list`, and `sync` against a checked-in `gh-secrets.json`:
   pushes to GitHub (wiremock) and a `.env` destination simultaneously;
@@ -335,8 +361,30 @@ Allowed types: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`,
   gh secret set GH_E2E_TOKEN --repo <owner>/<repo>
   # paste the token when prompted
   ```
-  Without the secret, the `live-e2e` job in `.github/workflows/ci.yml` is a
-  no-op. Rotate the PAT through the same command whenever needed.
+  Without the secret, the GitHub `live-e2e` step in `.github/workflows/ci.yml`
+  is a no-op. Rotate the PAT through the same command whenever needed.
+- The **isolated Bitwarden e2e account** is a throwaway Bitwarden account used
+  only by the live Bitwarden suite. Its api-key credentials live in two places,
+  kept in lockstep:
+  - In **the maintainer's own Bitwarden vault**, as three secure notes whose
+    note body holds the value: `BITWARDEN_TEST_CLIENT_ID`,
+    `BITWARDEN_TEST_CLIENT_SECRET`, `BITWARDEN_TEST_MASTER_PASSWORD`. That is
+    what `scripts/bw-e2e-env.sh` reads (via `gh-secrets ... --secret
+    NAME=ITEM#notes`) to run the suite locally — so a developer never copies the
+    isolated account's secret into a shell.
+  - As **repo secrets** for CI, so the `Live e2e (Bitwarden)` step in
+    `.github/workflows/ci.yml` can run (it installs the `bw` CLI and runs
+    `just test-live-bitwarden`):
+    ```
+    gh secret set GH_SECRETS_BW_E2E_CLIENT_ID     --repo <owner>/<repo>
+    gh secret set GH_SECRETS_BW_E2E_CLIENT_SECRET --repo <owner>/<repo>
+    gh secret set GH_SECRETS_BW_E2E_PASSWORD      --repo <owner>/<repo>
+    ```
+    The client id/secret are a Bitwarden **personal API key** (Account Settings
+    → Security → Keys → "View API Key"); the password is the isolated account's
+    master password. The step is guarded on `GH_SECRETS_BW_E2E_CLIENT_ID` being
+    set, so without the secrets it is skipped (not failed) — forks and
+    unconfigured repos stay green.
 - `scripts/install.sh` is the cross-platform installer (Linux x86_64 + arm64,
   macOS arm64, Windows x86_64 under a POSIX shell): it detects the host target,
   downloads the matching release archive, verifies its SHA-256, and installs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -372,7 +372,7 @@ Allowed types: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`,
     what `scripts/bw-e2e-env.sh` reads (via `gh-secrets ... --secret
     NAME=ITEM#notes`) to run the suite locally — so a developer never copies the
     isolated account's secret into a shell.
-  - As **repo secrets** for CI, so the `Live e2e (Bitwarden)` step in
+  - As **repo secrets** for CI, so the `live-e2e-bitwarden` job in
     `.github/workflows/ci.yml` can run (it installs the `bw` CLI and runs
     `just test-live-bitwarden`):
     ```
@@ -382,9 +382,11 @@ Allowed types: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`,
     ```
     The client id/secret are a Bitwarden **personal API key** (Account Settings
     → Security → Keys → "View API Key"); the password is the isolated account's
-    master password. The step is guarded on `GH_SECRETS_BW_E2E_CLIENT_ID` being
-    set, so without the secrets it is skipped (not failed) — forks and
-    unconfigured repos stay green.
+    master password. `live-e2e-bitwarden` is its own job (separate from the
+    GitHub `live-e2e`) and a **required status check** on `master`, so a
+    Bitwarden regression blocks merges. The run is guarded on
+    `GH_SECRETS_BW_E2E_CLIENT_ID` being set, so without the secrets it is
+    skipped (not failed) — forks and unconfigured repos stay green.
 - `scripts/install.sh` is the cross-platform installer (Linux x86_64 + arm64,
   macOS arm64, Windows x86_64 under a POSIX shell): it detects the host target,
   downloads the matching release archive, verifies its SHA-256, and installs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,10 @@ sha2 = "0.10"
 
 [dev-dependencies]
 assert_cmd = "2.0"
+# Encodes seeded Bitwarden items for the live e2e suite (`bw create item`
+# wants a base64 of the item JSON). Already a normal dependency; listed here so
+# the integration tests can use it too.
+base64 = "0.22"
 predicates = "3.1"
 tempfile = "3.13"
 wiremock = "0.6"

--- a/justfile
+++ b/justfile
@@ -20,17 +20,30 @@ test:
     cargo nextest run --lib --bins
 
 # End-to-end tests: drive the compiled binary against a mock GitHub server.
-# Also compiles+runs the live-test binary (`e2e_live`); each live test
-# early-returns as a no-op when `GH_SECRETS_LIVE_TEST` is unset, so the gate
-# catches breakage in the live test code without paying for network calls.
+# Also compiles+runs the live-test binaries (`e2e_live`, `e2e_live_bitwarden`);
+# each live test early-returns as a no-op when its gate env vars are unset, so
+# the default gate catches breakage in the live test code without paying for
+# network calls.
 test-e2e:
-    cargo nextest run --test e2e --test e2e_manifest --test e2e_auth --test e2e_live
+    cargo nextest run --test e2e --test e2e_manifest --test e2e_auth --test e2e_live --test e2e_live_bitwarden
 
 # Live end-to-end tests against the real GitHub API. Requires `GH_TOKEN` with
 # `repo` scope (covers `secrets:write`); creates and reuses a private sandbox
 # repo `gh-secrets-e2e-sandbox` on the authenticated user's account.
 test-live:
     GH_SECRETS_LIVE_TEST=1 cargo nextest run --test e2e_live --no-fail-fast
+
+# Live end-to-end tests against a real, isolated Bitwarden account. Requires the
+# isolated account's api-key credentials in the environment:
+# `GH_SECRETS_BW_E2E_CLIENT_ID`, `GH_SECRETS_BW_E2E_CLIENT_SECRET`,
+# `GH_SECRETS_BW_E2E_PASSWORD`, plus the `bw` CLI on PATH. Locally, run it via
+# `scripts/bw-e2e-env.sh just test-live-bitwarden`, which pulls those creds out
+# of your own vault (where they live as the `BITWARDEN_TEST_*` secure notes).
+# Without the creds, every test skips as a no-op. Runs serially (`-j1`): every
+# test logs in to the single isolated account, so parallel processes would pile
+# up concurrent api-key logins for no real gain on a 5-test suite.
+test-live-bitwarden:
+    GH_SECRETS_LIVE_TEST=1 cargo nextest run -j1 --test e2e_live_bitwarden --no-fail-fast
 
 # Lint with clippy. Warnings are errors.
 lint:

--- a/scripts/bw-e2e-env.sh
+++ b/scripts/bw-e2e-env.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# Run a command with the *isolated* Bitwarden e2e account's api-key credentials
+# exported, sourced from your own vault.
+#
+# The live Bitwarden suite (`just test-live-bitwarden`) needs the throwaway test
+# account's credentials in the environment as:
+#
+#   GH_SECRETS_BW_E2E_CLIENT_ID
+#   GH_SECRETS_BW_E2E_CLIENT_SECRET
+#   GH_SECRETS_BW_E2E_PASSWORD
+#
+# Those credentials are stored — for exactly this purpose — in *your* Bitwarden
+# vault as three secure notes (the value lives in each note's body):
+#
+#   BITWARDEN_TEST_CLIENT_ID
+#   BITWARDEN_TEST_CLIENT_SECRET
+#   BITWARDEN_TEST_MASTER_PASSWORD
+#
+# This script uses `gh-secrets` itself to pull those notes out of your vault and
+# into the GH_SECRETS_BW_E2E_* env vars, then exec's whatever command you pass.
+# It writes them only to a 0700 tempdir that is shredded on exit, and never
+# prints a value. Your own vault unlocks via the usual precedence (shell env >
+# .env > .env.local > stored config), so run it from the repo root.
+#
+# Usage:
+#   scripts/bw-e2e-env.sh just test-live-bitwarden
+#   scripts/bw-e2e-env.sh cargo nextest run --test e2e_live_bitwarden --no-fail-fast
+#
+# CI does NOT use this script — there the GH_SECRETS_BW_E2E_* vars come straight
+# from repo secrets. This is purely the local-developer convenience.
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: scripts/bw-e2e-env.sh <command> [args...]" >&2
+  exit 2
+fi
+
+# Run the product CLI. Inside the repo (Cargo.toml present) prefer the in-tree
+# build so this always matches the code under test, never a stale globally
+# installed `gh-secrets`; otherwise fall back to one on PATH.
+gh_secrets() {
+  if [ -f Cargo.toml ] && command -v cargo >/dev/null 2>&1; then
+    cargo run --quiet -- "$@"
+  elif command -v gh-secrets >/dev/null 2>&1; then
+    gh-secrets "$@"
+  else
+    echo "error: run from the repo root (needs Cargo.toml) or install gh-secrets" >&2
+    return 1
+  fi
+}
+
+tmp="$(mktemp -d)"
+chmod 700 "$tmp"
+home="$(mktemp -d)"
+cleanup() { rm -rf "$tmp" "$home"; }
+trap cleanup EXIT
+
+# Pull the three secure notes out of your vault into a dotenv file, mapping each
+# onto the env var the test suite reads. `#notes` selects the note body.
+GH_SECRETS_HOME="$home" gh_secrets sync \
+  --from bitwarden \
+  --to "env:$tmp/creds.env" \
+  --state "$tmp/state.json" \
+  --secret "GH_SECRETS_BW_E2E_CLIENT_ID=BITWARDEN_TEST_CLIENT_ID#notes" \
+  --secret "GH_SECRETS_BW_E2E_CLIENT_SECRET=BITWARDEN_TEST_CLIENT_SECRET#notes" \
+  --secret "GH_SECRETS_BW_E2E_PASSWORD=BITWARDEN_TEST_MASTER_PASSWORD#notes" \
+  >/dev/null
+
+# Load them into this shell (no echo), then hand off to the requested command.
+set -a
+# shellcheck disable=SC1091
+. "$tmp/creds.env"
+set +a
+
+exec "$@"

--- a/tests/e2e_live_bitwarden.rs
+++ b/tests/e2e_live_bitwarden.rs
@@ -1,0 +1,219 @@
+//! Live e2e tests against a **real, isolated** Bitwarden account.
+//!
+//! These prove the half of the pipeline the wiremock GitHub suite can't: that
+//! `gh-secrets` actually authenticates to Bitwarden (api-key login + master
+//! password unlock), syncs the vault, and pulls real values out of real items
+//! — password, username, notes, and custom fields — then pushes them to a
+//! destination, all without ever printing a value.
+//!
+//! They are skipped (as no-op passing tests) unless `GH_SECRETS_LIVE_TEST=1`
+//! and the isolated account's api-key credentials are present:
+//! `GH_SECRETS_BW_E2E_CLIENT_ID`, `GH_SECRETS_BW_E2E_CLIENT_SECRET`,
+//! `GH_SECRETS_BW_E2E_PASSWORD`. The account exists solely for this suite, so
+//! seeding and deleting items in it is safe; each test isolates itself with a
+//! unique item-name prefix and a throwaway `bw` app-data dir, and cleans up the
+//! items it creates in `Drop`. See `tests/live_bw_common/mod.rs` for the why.
+//!
+//! Run with: `just test-live-bitwarden` (which expects the three credentials in
+//! the environment; `scripts/bw-e2e-env.sh` populates them from the developer's
+//! own vault where the isolated account's keys are stored).
+
+#[macro_use]
+mod live_bw_common;
+
+use live_bw_common::BwLiveSession;
+use predicates::str::contains;
+use tempfile::TempDir;
+
+/// Read this session's env-file destination back as a string.
+fn dest_body(s: &BwLiveSession) -> String {
+    std::fs::read_to_string(s.dir.path().join("out.env")).expect("read out.env destination")
+}
+
+/// A login item's password reaches an env-file destination, and an immediate
+/// resync of the unchanged value is a genuine no-op — the central UX promise,
+/// proven end-to-end against real Bitwarden.
+#[test]
+fn live_bw_sync_password_then_noop_resync() {
+    skip_if_no_bw_live!();
+    let s = BwLiveSession::new("syncpw");
+    let pw = "live-bw-password-value-1";
+    let item = s.seed_login(
+        "LOGIN",
+        "unused-username",
+        pw,
+        "unused-notes",
+        ("CUSTOM", "unused"),
+    );
+
+    let assert = s
+        .cmd()
+        .args([
+            "sync",
+            "--from",
+            "bitwarden",
+            "--to",
+            "env:out.env",
+            "--secret",
+            &format!("GHSE2E_PW={item}"),
+        ])
+        .assert()
+        .success();
+    // The value must never appear in the CLI's own output.
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout).into_owned();
+    assert!(!stdout.contains(pw), "the secret value leaked to stdout");
+
+    assert!(
+        dest_body(&s).contains(&format!("GHSE2E_PW=\"{pw}\"")),
+        "expected the fetched password in the env destination"
+    );
+
+    // Re-sync: same source value, recorded state → nothing to do.
+    s.cmd()
+        .args([
+            "sync",
+            "--from",
+            "bitwarden",
+            "--to",
+            "env:out.env",
+            "--secret",
+            &format!("GHSE2E_PW={item}"),
+        ])
+        .assert()
+        .success()
+        .stdout(contains("nothing to do"));
+}
+
+/// Every supported field selector pulls the right value off one real item:
+/// the default `password`, plus `#username`, `#notes`, and `#fields.<NAME>`.
+#[test]
+fn live_bw_field_selectors_extract_each_field() {
+    skip_if_no_bw_live!();
+    let s = BwLiveSession::new("fields");
+    let (user, pw, notes, custom) = (
+        "username-value-2",
+        "password-value-2",
+        "notes-value-2",
+        "custom-field-value-2",
+    );
+    let item = s.seed_login("ITEM", user, pw, notes, ("API_URL", custom));
+
+    s.cmd()
+        .args([
+            "sync",
+            "--from",
+            "bitwarden",
+            "--to",
+            "env:out.env",
+            "--secret",
+            &format!("PW={item}"),
+            "--secret",
+            &format!("USER={item}#username"),
+            "--secret",
+            &format!("NOTE={item}#notes"),
+            "--secret",
+            &format!("CUST={item}#fields.API_URL"),
+        ])
+        .assert()
+        .success();
+
+    let body = dest_body(&s);
+    for (key, value) in [
+        ("PW", pw),
+        ("USER", user),
+        ("NOTE", notes),
+        ("CUST", custom),
+    ] {
+        assert!(
+            body.contains(&format!("{key}=\"{value}\"")),
+            "expected {key} from its field selector; got:\n{body}"
+        );
+    }
+}
+
+/// `source list` enumerates the vault by contacting Bitwarden directly, and
+/// prints item names but never a value.
+#[test]
+fn live_bw_source_list_shows_item_names_not_values() {
+    skip_if_no_bw_live!();
+    let s = BwLiveSession::new("list");
+    let secret_pw = "must-not-be-printed-3";
+    let item = s.seed_login("LISTME", "u", secret_pw, "n", ("C", "v"));
+
+    let assert = s
+        .cmd()
+        .args(["source", "list", "--from", "bitwarden"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout).into_owned();
+
+    assert!(
+        stdout.contains(&item),
+        "expected the seeded item name in `source list`; got:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains(secret_pw),
+        "`source list` must never print a value"
+    );
+}
+
+/// The full cold path through `gh-secrets` itself: pointed at a *fresh* `bw`
+/// app-data dir (no prior login), it must perform `bw login --apikey` → unlock
+/// → sync → fetch on its own and still land the value at the destination.
+#[test]
+fn live_bw_cold_login_full_path_fetches_value() {
+    skip_if_no_bw_live!();
+    let s = BwLiveSession::new("cold");
+    let pw = "cold-login-password-4";
+    let item = s.seed_login("COLD", "u", pw, "n", ("C", "v"));
+
+    // A pristine app-data dir: gh-secrets sees `unauthenticated` and runs the
+    // whole login/unlock/sync chain itself before fetching.
+    let fresh = TempDir::new().expect("fresh appdata dir");
+    s.cmd_in_appdata(fresh.path())
+        .args([
+            "sync",
+            "--from",
+            "bitwarden",
+            "--to",
+            "env:out.env",
+            "--secret",
+            &format!("COLDPW={item}"),
+        ])
+        .assert()
+        .success();
+
+    assert!(
+        dest_body(&s).contains(&format!("COLDPW=\"{pw}\"")),
+        "expected the value fetched via a cold gh-secrets login"
+    );
+}
+
+/// A wrong master password surfaces a precise unlock error (never a hang), with
+/// no value written. Exercises the real Bitwarden unlock-failure path.
+#[test]
+fn live_bw_wrong_master_password_errors_clearly() {
+    skip_if_no_bw_live!();
+    let s = BwLiveSession::new("wrongpw");
+    let item = s.seed_login("WPW", "u", "p", "n", ("C", "v"));
+
+    s.cmd()
+        .env("BW_PASSWORD", "this-is-not-the-master-password")
+        .args([
+            "sync",
+            "--from",
+            "bitwarden",
+            "--to",
+            "env:out.env",
+            "--secret",
+            &format!("WPW={item}"),
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("unlock"));
+
+    assert!(
+        !s.dir.path().join("out.env").exists(),
+        "nothing should be written when the unlock fails"
+    );
+}

--- a/tests/live_bw_common/mod.rs
+++ b/tests/live_bw_common/mod.rs
@@ -1,0 +1,323 @@
+//! Helpers for the live Bitwarden e2e suite (`tests/e2e_live_bitwarden.rs`).
+//!
+//! These drive `gh-secrets` against a **real** Bitwarden account — an isolated
+//! account that exists only for this test (so seeding and deleting items in it
+//! is safe). They are gated twice: `GH_SECRETS_LIVE_TEST=1` *and* the isolated
+//! account's API-key credentials present in the environment. When either is
+//! missing, callers must early-return (via `skip_if_no_bw_live!`) so the
+//! default gate still compiles and runs the binary as cheap no-ops.
+//!
+//! ## Isolation from the developer's own Bitwarden
+//!
+//! The `bw` CLI keeps all of its state (the logged-in account, the encrypted
+//! vault cache, the session) in a single app-data directory. A developer
+//! running this suite is almost certainly already logged in to their *own*
+//! Bitwarden account in the default location. So every session here points
+//! `BITWARDENCLI_APPDATA_DIR` at its own tempdir: `bw login --apikey` against
+//! the isolated account lands in that throwaway dir and never disturbs (or is
+//! confused by) the developer's real login. Crucially, `gh-secrets` spawns
+//! `bw` as a child that inherits this env var, so pointing the *gh-secrets*
+//! process at the tempdir flows all the way down to the `bw` it shells out to.
+//!
+//! ## Why each test logs in independently
+//!
+//! nextest runs each `#[test]` in its own process, so there is no in-process
+//! state to share — a `OnceLock` login would re-run once per test anyway.
+//! Giving every test its own app-data tempdir keeps them from racing on `bw`'s
+//! state files, so they remain safe to run in parallel; isolation on the
+//! Bitwarden side comes from a per-test item-name prefix plus `Drop` cleanup.
+
+use std::process::Command as StdCommand;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use assert_cmd::Command;
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+pub const LIVE_ENV: &str = "GH_SECRETS_LIVE_TEST";
+
+/// Env vars the isolated account's API-key credentials are read from. These are
+/// deliberately distinct from the canonical `BW_*`/`BITWARDEN_*` names so a
+/// developer's own logged-in Bitwarden credentials can never be mistaken for
+/// the throwaway test account's.
+pub const CLIENT_ID_ENV: &str = "GH_SECRETS_BW_E2E_CLIENT_ID";
+pub const CLIENT_SECRET_ENV: &str = "GH_SECRETS_BW_E2E_CLIENT_SECRET";
+pub const PASSWORD_ENV: &str = "GH_SECRETS_BW_E2E_PASSWORD";
+
+pub fn live_enabled() -> bool {
+    std::env::var(LIVE_ENV).as_deref() == Ok("1")
+}
+
+fn env_nonempty(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|v| !v.is_empty())
+}
+
+/// The isolated account's resolved API-key credentials, or `None` if any are
+/// missing (in which case the suite skips).
+pub fn creds() -> Option<BwCreds> {
+    Some(BwCreds {
+        client_id: env_nonempty(CLIENT_ID_ENV)?,
+        client_secret: env_nonempty(CLIENT_SECRET_ENV)?,
+        password: env_nonempty(PASSWORD_ENV)?,
+    })
+}
+
+/// True only when both gates are satisfied: live mode on *and* the isolated
+/// account's credentials available.
+pub fn bw_live_enabled() -> bool {
+    live_enabled() && creds().is_some()
+}
+
+#[macro_export]
+macro_rules! skip_if_no_bw_live {
+    () => {
+        if !$crate::live_bw_common::bw_live_enabled() {
+            eprintln!(
+                "skip: live bitwarden test (set {}=1 + {}/{}/{} to run)",
+                $crate::live_bw_common::LIVE_ENV,
+                $crate::live_bw_common::CLIENT_ID_ENV,
+                $crate::live_bw_common::CLIENT_SECRET_ENV,
+                $crate::live_bw_common::PASSWORD_ENV,
+            );
+            return;
+        }
+    };
+}
+
+#[derive(Clone)]
+pub struct BwCreds {
+    pub client_id: String,
+    pub client_secret: String,
+    pub password: String,
+}
+
+/// One test's worth of state against the isolated Bitwarden account:
+///
+/// - `home` — an isolated `GH_SECRETS_HOME` config root.
+/// - `dir` — a working directory for the run's env-file destinations + state.
+/// - `appdata` — the throwaway `bw` app-data dir this session logs in to.
+/// - `prefix` — a unique item-name prefix so parallel tests never collide.
+/// - `session` — an unlocked `bw` session for the isolated vault, used to seed
+///   and tear down items directly (the product CLI cannot write to Bitwarden).
+pub struct BwLiveSession {
+    pub home: TempDir,
+    pub dir: TempDir,
+    pub appdata: TempDir,
+    pub prefix: String,
+    creds: BwCreds,
+    session: String,
+    created_ids: Mutex<Vec<String>>,
+}
+
+impl BwLiveSession {
+    /// Log in to the isolated account in a fresh app-data dir and unlock it,
+    /// leaving a ready-to-seed session. Panics (failing the test loudly) if any
+    /// step fails — these run only when `bw_live_enabled()`.
+    pub fn new(test_name: &str) -> Self {
+        assert!(
+            bw_live_enabled(),
+            "BwLiveSession::new called while disabled; tests must skip first"
+        );
+        let creds = creds().expect("creds present (checked by bw_live_enabled)");
+        let home = TempDir::new().expect("tempdir");
+        let dir = TempDir::new().expect("tempdir");
+        let appdata = TempDir::new().expect("tempdir");
+
+        // Cold login + unlock against the isolated account in our own app-data
+        // dir, exercising the exact `bw` commands the product CLI runs.
+        bw_checked(
+            &appdata,
+            &["login", "--apikey"],
+            &[
+                ("BW_CLIENTID", &creds.client_id),
+                ("BW_CLIENTSECRET", &creds.client_secret),
+            ],
+        );
+        let session = bw_checked(
+            &appdata,
+            &["unlock", "--raw", "--passwordenv", "BW_PASSWORD"],
+            &[("BW_PASSWORD", &creds.password)],
+        )
+        .trim()
+        .to_string();
+        assert!(!session.is_empty(), "bw unlock returned an empty session");
+        bw_checked(&appdata, &["sync", "--session", &session], &[]);
+
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let prefix = format!("ghse2e_{}_{nanos}_{n}", sanitize(test_name));
+
+        Self {
+            home,
+            dir,
+            appdata,
+            prefix,
+            creds,
+            session,
+            created_ids: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// A `gh-secrets` command pointed at this session's isolated config root and
+    /// `bw` app-data dir, carrying the isolated account's credentials under the
+    /// canonical `BW_*` names. Any inherited Bitwarden state (a developer's
+    /// session/creds, or a real `GH_SECRETS_API_BASE`) is scrubbed so the run
+    /// is deterministic. Because the app-data dir is already logged-in+unlocked,
+    /// this exercises gh-secrets' status → unlock → sync → fetch path.
+    pub fn cmd(&self) -> Command {
+        self.cmd_in_appdata(self.appdata.path())
+    }
+
+    /// Like [`cmd`](Self::cmd) but points `bw` at an arbitrary app-data dir.
+    /// Passing a *fresh* (unauthenticated) dir makes gh-secrets perform the
+    /// full cold path itself: `bw login --apikey` → unlock → sync → fetch.
+    pub fn cmd_in_appdata(&self, appdata: &std::path::Path) -> Command {
+        let mut c = Command::cargo_bin("gh-secrets").expect("locate gh-secrets bin");
+        c.current_dir(self.dir.path())
+            .env("GH_SECRETS_HOME", self.home.path())
+            .env("BITWARDENCLI_APPDATA_DIR", appdata)
+            .env("BW_CLIENTID", &self.creds.client_id)
+            .env("BW_CLIENTSECRET", &self.creds.client_secret)
+            .env("BW_PASSWORD", &self.creds.password)
+            .env_remove("GH_SECRETS_API_BASE")
+            .env_remove("BW_SESSION")
+            .env_remove("BITWARDEN_SESSION")
+            .env_remove("BITWARDEN_CLIENT_ID")
+            .env_remove("BITWARDEN_CLIENT_SECRET")
+            .env_remove("BITWARDEN_MASTER_PASSWORD")
+            .env_remove("BITWARDEN_PASSWORD");
+        c
+    }
+
+    /// A unique Bitwarden item name for this session.
+    pub fn item_name(&self, leaf: &str) -> String {
+        format!("{}_{}", self.prefix, sanitize(leaf))
+    }
+
+    /// Seed a Login item in the isolated vault, returning its name. The item
+    /// carries a username, password, notes, and one hidden custom field so the
+    /// field-selector tests can pull each one back out. Records the created id
+    /// for `Drop` cleanup.
+    #[allow(clippy::too_many_arguments)]
+    pub fn seed_login(
+        &self,
+        leaf: &str,
+        username: &str,
+        password: &str,
+        notes: &str,
+        custom_field: (&str, &str),
+    ) -> String {
+        let name = self.item_name(leaf);
+        let item = json!({
+            "organizationId": null,
+            "collectionIds": null,
+            "folderId": null,
+            "type": 1, // Login
+            "name": name,
+            "notes": notes,
+            "favorite": false,
+            "fields": [{ "name": custom_field.0, "value": custom_field.1, "type": 1 }],
+            "login": { "username": username, "password": password, "uris": [], "totp": null },
+            "reprompt": 0,
+        });
+        let encoded = {
+            use base64::Engine;
+            base64::engine::general_purpose::STANDARD.encode(item.to_string())
+        };
+        let out = bw_checked(
+            &self.appdata,
+            &["create", "item", &encoded, "--session", &self.session],
+            &[],
+        );
+        let created: Value = serde_json::from_str(&out).expect("parse created item JSON");
+        let id = created["id"]
+            .as_str()
+            .expect("created item has an id")
+            .to_string();
+        self.created_ids.lock().unwrap().push(id);
+        name
+    }
+}
+
+impl Drop for BwLiveSession {
+    fn drop(&mut self) {
+        // Best-effort cleanup, then log out so the throwaway app-data dir leaves
+        // no lingering server session.
+        //
+        // Re-unlock for a fresh session rather than reusing `self.session`: when
+        // a test let gh-secrets unlock *this same* app-data dir, that minted a
+        // new session and invalidated ours, so a delete with the stale token
+        // would silently no-op. A fresh unlock (the dir is still logged in)
+        // always yields a usable session. `--permanent` deletes outright instead
+        // of leaving the item in the vault's trash.
+        let ids = self.created_ids.lock().unwrap().clone();
+        if !ids.is_empty() {
+            if let Ok(out) = run_bw(
+                &self.appdata,
+                &["unlock", "--raw", "--passwordenv", "BW_PASSWORD"],
+                &[("BW_PASSWORD", &self.creds.password)],
+            ) {
+                if out.status.success() {
+                    let session = String::from_utf8_lossy(&out.stdout).trim().to_string();
+                    let _ = run_bw(&self.appdata, &["sync", "--session", &session], &[]);
+                    for id in &ids {
+                        let _ = run_bw(
+                            &self.appdata,
+                            &["delete", "item", id, "--permanent", "--session", &session],
+                            &[],
+                        );
+                    }
+                }
+            }
+        }
+        let _ = run_bw(&self.appdata, &["logout"], &[]);
+    }
+}
+
+fn sanitize(s: &str) -> String {
+    s.chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect()
+}
+
+/// Run `bw` with the given app-data dir and extra env, returning the raw
+/// `Output`. The app-data dir is the isolation boundary; extra env carries
+/// credentials `bw` reads natively (`BW_CLIENTID`, `BW_PASSWORD`, ...).
+fn run_bw(
+    appdata: &TempDir,
+    args: &[&str],
+    env: &[(&str, &str)],
+) -> std::io::Result<std::process::Output> {
+    let mut cmd = StdCommand::new("bw");
+    cmd.args(args)
+        .env("BITWARDENCLI_APPDATA_DIR", appdata.path());
+    for (k, v) in env {
+        cmd.env(k, v);
+    }
+    cmd.output()
+}
+
+/// Run `bw` and return its stdout as a `String`, panicking with stderr on
+/// failure so a broken setup step fails the test with a clear message. `bw`
+/// never writes a secret value to stderr, so surfacing it is safe.
+fn bw_checked(appdata: &TempDir, args: &[&str], env: &[(&str, &str)]) -> String {
+    let out = run_bw(appdata, args, env).unwrap_or_else(|e| {
+        panic!(
+            "running `bw {}`: {e} (is the Bitwarden CLI installed?)",
+            args[0]
+        )
+    });
+    assert!(
+        out.status.success(),
+        "`bw {}` failed: {}",
+        args[0],
+        String::from_utf8_lossy(&out.stderr).trim()
+    );
+    String::from_utf8(out.stdout).expect("bw stdout is UTF-8")
+}


### PR DESCRIPTION
## What

Adds a real-API end-to-end suite that drives `gh-secrets` against a real, **isolated** Bitwarden account (one that exists only for this test, so seeding/deleting items in it is safe). This covers the source half the wiremock GitHub suites can't: the actual Bitwarden auth chain.

`tests/e2e_live_bitwarden.rs` (5 tests):
- password → env destination, plus a no-op resync
- every field selector: `password`, `#username`, `#notes`, `#fields.<NAME>`
- `source list` enumerates items, never prints a value
- the **cold** path through gh-secrets itself: `bw login --apikey` → unlock → sync → fetch
- a wrong master password surfaces a precise unlock error with nothing written

## How it stays safe & isolated

- Each test points `BITWARDENCLI_APPDATA_DIR` at its own tempdir, so it never disturbs (or is confused by) a developer's real `bw` login. gh-secrets' spawned `bw` inherits it.
- Each test seeds uniquely-prefixed items via `bw` directly and `--permanent`-deletes them in `Drop` (re-unlocking for a fresh session first, since a gh-secrets unlock of the same app-data dir invalidates the seed session).
- Double-gated: skips as a no-op unless `GH_SECRETS_LIVE_TEST=1` **and** the isolated account's creds are present, so the default gate still compiles and exercises the code path with zero network calls.

## Wiring

- `just test-live-bitwarden` (serial) + the binary added to the default-gate `test-e2e`.
- CI `Live e2e (Bitwarden)` step installs `bw` and runs the suite, guarded on `GH_SECRETS_BW_E2E_CLIENT_ID` so forks/unconfigured repos stay green. The three `GH_SECRETS_BW_E2E_*` repo secrets are set.
- `scripts/bw-e2e-env.sh` runs it locally by pulling the creds from the maintainer's own vault (the `BITWARDEN_TEST_*` notes) — the secret never lands in a shell.
- `AGENTS.md` documents the isolated account, where its keys live, and the app-data-dir isolation.

## Verification

- Live suite: **5/5 passed** against the real isolated account; teardown leaves the vault with **0 active items, 0 trash**.
- Offline gate: `fmt --check` ✓, `clippy -D warnings` ✓, 108 tests ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)