### PR TITLE
test: expand e2e coverage of failure paths, drift healing, and auth edges

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,7 +248,19 @@ Project-local layout and credentials:
   --global`; `init` / `--path` / `--global` incl. overwrite refusals; error
   edges (source missing a declared value, Bitwarden scoping flags on a
   non-bitwarden source, empty store name); and the structural sealed-box
-  assertion on the PUT body so a broken seal step can't slip through.
+  assertion on the PUT body so a broken seal step can't slip through. It also
+  pins the failure/drift surface: the 401/403/404/500 message mapping on both
+  the public-key GET and the PUT, the 204→"updated" report, malformed
+  public-key rejection (wrong length, non-JSON); partial-failure semantics (a
+  failed destination records *no* state, so the re-run repushes); the state
+  file holding hashes only, and a deleted state file merely forcing a
+  re-push; out-of-band edits to readable destinations (env file, local
+  store) healed by `sync` while `check` stays state-only by design; hostile
+  values (quotes, `$`, backticks, newlines) round-tripping env-destination →
+  env-source with byte-identical canonical lines; invalid `--from`/`--to`/
+  `--secret` specs and malformed/unknown-type configs erroring with the
+  spec/file named; and `list` rendering the Bitwarden mapping (incl.
+  `default_field` and per-secret `field` overrides) with no credentials.
 - The live e2e suite (`tests/e2e_live.rs`) round-trips the same `sync`
   pipeline (env-file source → real `github:` destination) against the real
   GitHub API: a secret becomes visible via the API after sync, a resync is a
@@ -263,9 +275,11 @@ Project-local layout and credentials:
   suites can't — api-key login + master-password unlock + vault sync — then
   pulls real values off real items through every field selector (`password`,
   `#username`, `#notes`, `#fields.<NAME>`) to an env-file destination, asserts
-  a no-op resync, runs the full cold path through gh-secrets itself (login →
-  unlock → sync → fetch), and confirms a wrong master password yields a precise
-  unlock error with nothing written. Each test seeds uniquely-prefixed items
+  a no-op resync, proves `--default-field` changes what an unselected secret
+  extracts (with a per-secret `#field` still overriding it), runs the full
+  cold path through gh-secrets itself (login → unlock → sync → fetch), and
+  confirms a wrong master password yields a precise unlock error with nothing
+  written. Each test seeds uniquely-prefixed items
   via `bw` directly (the product CLI is write-only-blocked for Bitwarden) and
   deletes them in `Drop`. The hard-won isolation detail: every test points
   `BITWARDENCLI_APPDATA_DIR` at its own tempdir, and gh-secrets' spawned `bw`
@@ -286,12 +300,21 @@ Project-local layout and credentials:
   without a passphrase in a non-interactive run, and rejects a wrong
   passphrase with a decryption error); the session lifecycle (`auth unlock`
   lets fresh processes read *and* write with no passphrase anywhere in the
-  environment, expiry and `auth lock` revoke it, and a session cannot extend
-  itself); and — the key assertion — a real `sync`
+  environment, expiry and `auth lock` revoke it, a session cannot extend
+  itself, and a session left over from a *recreated* vault is detected as
+  mismatched and deleted on sight); selective clears (`--github` /
+  `--bitwarden`) and the empty-token / no-flag / lock-with-no-session edges;
+  and — the key assertion — a real `sync`
   against a wiremock GitHub records the exact `Authorization` bearer, so each
   test can confirm the token that *won* (shell env, `.env`, `.env.local`, or
   stored config) is the one that actually reached the API. The dotenv
   parser/precedence planner is also unit-tested in `src/envfile.rs`.
+- Deliberately *not* e2e-tested: the interactive passphrase prompt and the
+  session it auto-mints on a prompted unlock. Those paths need a PTY
+  (`rpassword` + `stdin.is_terminal()`), and a PTY harness is flakier than
+  the coverage is worth; the logic is unit-tested in `vault.rs` and the
+  non-interactive fallbacks (env passphrase, precise no-passphrase error) are
+  e2e-tested. Don't bolt a PTY driver onto the suite to close this gap.
 
 ## Conventional Commits
 

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -761,6 +761,537 @@ async fn e2e_sync_error_and_noop_edges() {
         .stderr(contains("name cannot be empty"));
 }
 
+/// GitHub error statuses surface the precise, actionable message from
+/// `github.rs` — both on the PUT and on the public-key GET — instead of a
+/// generic HTTP failure.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_github_error_statuses_surface_actionable_messages() {
+    let cases: [(u16, &str); 4] = [
+        (401, "set a valid token"),
+        (403, "lacks the required permissions"),
+        (404, "check the repository name"),
+        (500, "GitHub request failed"),
+    ];
+
+    // Failures on the PUT itself.
+    for (status, phrase) in cases {
+        let h = Harness::new().await;
+        h.write("source.env", "FOO=1\n");
+        Mock::given(method("GET"))
+            .and(path_regex(
+                "^/repos/owner/repo1/actions/secrets/public-key$",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "key_id": "kid-1",
+                "key": fake_pubkey_b64(),
+            })))
+            .mount(&h.server)
+            .await;
+        Mock::given(method("PUT"))
+            .and(path_regex("^/repos/owner/repo1/actions/secrets/(.+)$"))
+            .respond_with(ResponseTemplate::new(status))
+            .mount(&h.server)
+            .await;
+        h.cmd()
+            .args(sync_args())
+            .assert()
+            .failure()
+            .stderr(contains(status.to_string()))
+            .stderr(contains(phrase))
+            .stderr(contains("uploading 'FOO' to owner/repo1"));
+    }
+
+    // Failures fetching the public key get their own context.
+    for (status, phrase) in cases {
+        let h = Harness::new().await;
+        h.write("source.env", "FOO=1\n");
+        Mock::given(method("GET"))
+            .and(path_regex(
+                "^/repos/owner/repo1/actions/secrets/public-key$",
+            ))
+            .respond_with(ResponseTemplate::new(status))
+            .mount(&h.server)
+            .await;
+        h.cmd()
+            .args(sync_args())
+            .assert()
+            .failure()
+            .stderr(contains(status.to_string()))
+            .stderr(contains(phrase))
+            .stderr(contains("fetching public key for owner/repo1"));
+    }
+}
+
+/// The `sync` args every GitHub error-path test shares: one secret from an
+/// env-file source to the mocked `owner/repo1`.
+fn sync_args() -> [&'static str; 7] {
+    [
+        "sync",
+        "--from",
+        "env:source.env",
+        "--to",
+        "github:owner/repo1",
+        "--secret",
+        "FOO",
+    ]
+}
+
+/// A PUT answered with 204 (secret already existed) is reported as "updated",
+/// not "created" — the only place the created/updated wire distinction shows.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_put_204_reports_updated() {
+    let h = Harness::new().await;
+    h.write("source.env", "FOO=1\n");
+    Mock::given(method("GET"))
+        .and(path_regex(
+            "^/repos/owner/repo1/actions/secrets/public-key$",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "key_id": "kid-1",
+            "key": fake_pubkey_b64(),
+        })))
+        .mount(&h.server)
+        .await;
+    Mock::given(method("PUT"))
+        .and(path_regex("^/repos/owner/repo1/actions/secrets/(.+)$"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&h.server)
+        .await;
+
+    h.cmd()
+        .args(sync_args())
+        .assert()
+        .success()
+        .stdout(contains("github:owner/repo1: updated 'FOO'"))
+        .stdout(contains("0 created, 1 updated, 0 unchanged"));
+}
+
+/// A malformed public-key response is rejected at the trust boundary with a
+/// precise error — wrong key length and non-JSON body each name the problem.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_malformed_public_key_is_a_precise_error() {
+    // 31 bytes is not a valid X25519 public key.
+    let h = Harness::new().await;
+    h.write("source.env", "FOO=1\n");
+    Mock::given(method("GET"))
+        .and(path_regex(
+            "^/repos/owner/repo1/actions/secrets/public-key$",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "key_id": "kid-1",
+            "key": B64.encode([7u8; 31]),
+        })))
+        .mount(&h.server)
+        .await;
+    h.cmd()
+        .args(sync_args())
+        .assert()
+        .failure()
+        .stderr(contains("wrong length"));
+
+    // A body that isn't the documented JSON shape fails parsing, with context.
+    let h = Harness::new().await;
+    h.write("source.env", "FOO=1\n");
+    Mock::given(method("GET"))
+        .and(path_regex(
+            "^/repos/owner/repo1/actions/secrets/public-key$",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_string("not json"))
+        .mount(&h.server)
+        .await;
+    h.cmd()
+        .args(sync_args())
+        .assert()
+        .failure()
+        .stderr(contains("parsing public-key for owner/repo1"));
+}
+
+/// When one destination fails mid-sync, no state is recorded for *any*
+/// destination — so the next run re-pushes everything rather than silently
+/// believing a push that never landed. The earlier destination's write stands
+/// (its content is the source of truth on the re-run).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_failed_destination_records_no_state_so_rerun_repushes() {
+    let h = Harness::new().await;
+    let repo = "owner/repo1";
+    // Exactly one 500, mounted at higher priority than the recording PUT the
+    // harness mounts below; every later PUT succeeds.
+    Mock::given(method("PUT"))
+        .and(path_regex(format!("^/repos/{repo}/actions/secrets/(.+)$")))
+        .respond_with(ResponseTemplate::new(500))
+        .up_to_n_times(1)
+        .with_priority(1)
+        .mount(&h.server)
+        .await;
+    h.mount_github(repo).await;
+    // env destination first, github second: the env write succeeds before the
+    // github destination aborts the run.
+    h.write(
+        "gh-secrets.json",
+        &serde_json::to_string_pretty(&json!({
+            "source": {"type": "env_file", "path": "source.env"},
+            "secrets": [{"name": "FOO"}],
+            "destinations": [
+                {"type": "env_file", "path": "out.env"},
+                {"type": "github", "repository": repo},
+            ],
+        }))
+        .unwrap(),
+    );
+    h.write("source.env", "FOO=v1\n");
+
+    h.cmd()
+        .args(["sync"])
+        .assert()
+        .failure()
+        .stderr(contains(format!("applying to destination github:{repo}")));
+    assert!(h.read("out.env").contains("FOO=\"v1\""), "env write landed");
+    assert!(
+        !h.dir.path().join(".gh-secrets-state.json").exists(),
+        "a failed sync must not record state"
+    );
+
+    // The re-run pushes to GitHub and converges; a third run is the no-op.
+    h.cmd().args(["sync"]).assert().success();
+    assert_eq!(h.put_count(), 1, "the re-run repushed the failed secret");
+    h.cmd()
+        .args(["sync"])
+        .assert()
+        .success()
+        .stdout(contains("nothing to do"));
+    assert_eq!(h.put_count(), 1);
+}
+
+/// The state file holds hashes, never values — and deleting it merely forces
+/// a re-push (losing it leaks nothing and breaks nothing).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_state_file_holds_no_values_and_deleting_it_forces_repush() {
+    let h = Harness::new().await;
+    let repo = "owner/repo1";
+    h.mount_github(repo).await;
+    h.write("source.env", "FOO=\"state-secret-value\"\n");
+    let args = [
+        "sync",
+        "--from",
+        "env:source.env",
+        "--to",
+        "github:owner/repo1",
+        "--secret",
+        "FOO",
+    ];
+    h.cmd().args(args).assert().success();
+    assert_eq!(h.put_count(), 1);
+
+    let state = h.read(".gh-secrets-state.json");
+    assert!(
+        !state.contains("state-secret-value"),
+        "plaintext leaked into the state file"
+    );
+    assert!(
+        state.contains(&format!("github:{repo}")),
+        "state keys on the destination"
+    );
+
+    fs::remove_file(h.dir.path().join(".gh-secrets-state.json")).unwrap();
+    h.cmd().args(args).assert().success();
+    assert_eq!(h.put_count(), 2, "lost state forces a re-push");
+    h.cmd()
+        .args(args)
+        .assert()
+        .success()
+        .stdout(contains("nothing to do"));
+    assert_eq!(h.put_count(), 2);
+}
+
+/// Out-of-band edits to a readable destination are healed by `sync` even when
+/// the recorded state says nothing changed — while `check` (state-only by
+/// design) keeps reporting clean. Unrelated lines survive every heal.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_sync_heals_out_of_band_env_edits_while_check_stays_state_only() {
+    let h = Harness::new().await;
+    h.write("source.env", "FOO=canonical\n");
+    h.write("out.env", "# pinned comment\nOTHER=keepme\n");
+    let sync = [
+        "sync",
+        "--from",
+        "env:source.env",
+        "--to",
+        "env:out.env",
+        "--secret",
+        "FOO",
+    ];
+    let check = [
+        "check",
+        "--from",
+        "env:source.env",
+        "--to",
+        "env:out.env",
+        "--secret",
+        "FOO",
+    ];
+    h.cmd().args(sync).assert().success();
+    assert!(h.read("out.env").contains("FOO=\"canonical\""));
+
+    // Tamper with the managed line: check judges from state alone and stays
+    // clean; sync compares content and rewrites the canonical line.
+    h.write(
+        "out.env",
+        "# pinned comment\nOTHER=keepme\nFOO=\"tampered\"\n",
+    );
+    h.cmd()
+        .args(check)
+        .assert()
+        .success()
+        .stdout(contains("everything is up to date"));
+    h.cmd()
+        .args(sync)
+        .assert()
+        .success()
+        .stdout(contains("updated 'FOO'"));
+    let healed = h.read("out.env");
+    assert!(healed.contains("FOO=\"canonical\""));
+    assert!(healed.contains("# pinned comment"));
+    assert!(healed.contains("OTHER=keepme"));
+
+    // Delete the managed line entirely: sync re-creates it.
+    h.write("out.env", "# pinned comment\nOTHER=keepme\n");
+    h.cmd()
+        .args(sync)
+        .assert()
+        .success()
+        .stdout(contains("created 'FOO'"));
+    assert!(h.read("out.env").contains("FOO=\"canonical\""));
+
+    // Converged again: the next run is a genuine no-op.
+    h.cmd()
+        .args(sync)
+        .assert()
+        .success()
+        .stdout(contains("nothing to do"));
+}
+
+/// The local store is the other readable destination: a value changed behind
+/// the sync's back (`store set`) is healed on the next run.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_sync_heals_local_store_drift() {
+    let h = Harness::new().await;
+    h.write("source.env", "FOO=canonical\n");
+    let sync = [
+        "sync",
+        "--from",
+        "env:source.env",
+        "--to",
+        "local",
+        "--secret",
+        "FOO",
+    ];
+    h.cmd().args(sync).assert().success();
+    h.cmd()
+        .args(["store", "set", "FOO", "drifted"])
+        .assert()
+        .success();
+
+    h.cmd()
+        .args(sync)
+        .assert()
+        .success()
+        .stdout(contains("updated 'FOO'"));
+    h.cmd()
+        .args(sync)
+        .assert()
+        .success()
+        .stdout(contains("nothing to do"));
+
+    // Read the healed value back out through the store-as-source path.
+    h.cmd()
+        .args([
+            "sync",
+            "--from",
+            "local",
+            "--to",
+            "env:verify.env",
+            "--secret",
+            "FOO",
+        ])
+        .assert()
+        .success();
+    assert!(h.read("verify.env").contains("FOO=\"canonical\""));
+}
+
+/// Values full of shell-hostile characters survive a round trip: what the env
+/// destination writes, the env source reads back to the identical value (the
+/// canonical lines of two generations match exactly).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_env_destination_round_trips_hostile_values() {
+    let h = Harness::new().await;
+    let hostile = "a\"quote b\\slash $dollar `tick\nnewline\ttab";
+    h.cmd()
+        .args(["store", "set", "NASTY"])
+        .write_stdin(format!("{hostile}\n"))
+        .assert()
+        .success();
+
+    h.cmd()
+        .args([
+            "sync",
+            "--from",
+            "local",
+            "--to",
+            "env:gen1.env",
+            "--secret",
+            "NASTY",
+        ])
+        .assert()
+        .success();
+    h.cmd()
+        .args([
+            "sync",
+            "--from",
+            "env:gen1.env",
+            "--to",
+            "env:gen2.env",
+            "--secret",
+            "NASTY",
+        ])
+        .assert()
+        .success();
+
+    let gen1 = h.read("gen1.env");
+    let gen2 = h.read("gen2.env");
+    assert_eq!(gen1, gen2, "format -> parse -> format must be stable");
+    // Spot-check the escapes actually exercised the quoting rules.
+    assert!(gen1.contains("\\\"") && gen1.contains("\\$") && gen1.contains("\\n"));
+}
+
+/// Invalid store specs and secret specs fail through the binary with the
+/// guidance the parser promises.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_invalid_spec_errors_name_the_problem() {
+    let h = Harness::new().await;
+    h.write("source.env", "FOO=1\n");
+
+    h.cmd()
+        .args(["sync", "--from", "env:source.env", "--to", "bitwarden"])
+        .assert()
+        .failure()
+        .stderr(contains("not yet supported"));
+
+    h.cmd()
+        .args([
+            "sync",
+            "--from",
+            "env:source.env",
+            "--to",
+            "github:just-a-name",
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("github:<owner>/<repo>"));
+
+    h.cmd()
+        .args(["sync", "--from", "nope", "--to", "env:out.env"])
+        .assert()
+        .failure()
+        .stderr(contains("invalid source 'nope'"));
+
+    h.cmd()
+        .args([
+            "sync",
+            "--from",
+            "env:source.env",
+            "--to",
+            "env:out.env",
+            "--secret",
+            "=item",
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("name is empty"));
+
+    // `store set` from a pipe with nothing on stdin is an error, not an empty
+    // secret.
+    h.cmd()
+        .args(["store", "set", "FOO"])
+        .write_stdin("")
+        .assert()
+        .failure()
+        .stderr(contains("no value provided on stdin"));
+}
+
+/// A broken config file is an error that names the file — malformed JSON and
+/// an unknown store type both fail at the trust boundary.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_malformed_config_errors_name_the_file() {
+    let h = Harness::new().await;
+    h.write("gh-secrets.json", "{ not json");
+    h.cmd()
+        .args(["sync"])
+        .assert()
+        .failure()
+        .stderr(contains("gh-secrets.json"));
+
+    h.write(
+        "gh-secrets.json",
+        &serde_json::to_string_pretty(&json!({
+            "source": {"type": "carrier-pigeon"},
+            "secrets": [{"name": "FOO"}],
+            "destinations": [],
+        }))
+        .unwrap(),
+    );
+    h.cmd()
+        .args(["list"])
+        .assert()
+        .failure()
+        .stderr(contains("gh-secrets.json"))
+        .stderr(contains("carrier-pigeon"));
+}
+
+/// `list` renders the Bitwarden mapping — including the config's
+/// `default_field` and per-secret `field` overrides — without contacting
+/// Bitwarden or needing any credential.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_list_renders_bitwarden_mapping_with_default_field() {
+    let h = Harness::new().await;
+    h.write(
+        "gh-secrets.json",
+        &serde_json::to_string_pretty(&json!({
+            "source": {"type": "bitwarden", "default_field": "fields.TOKEN"},
+            "secrets": [
+                {"name": "PLAIN"},
+                {"name": "NOTEY", "item": "shared item", "field": "notes"},
+            ],
+            "destinations": [{"type": "github", "repository": "owner/repo1"}],
+        }))
+        .unwrap(),
+    );
+    h.cmd()
+        .args(["list"])
+        .assert()
+        .success()
+        .stdout(contains("source: bitwarden"))
+        .stdout(contains(
+            "PLAIN  (bitwarden item 'PLAIN', field 'fields.TOKEN')",
+        ))
+        .stdout(contains(
+            "NOTEY  (bitwarden item 'shared item', field 'notes')",
+        ));
+
+    // Without a default_field the implicit `password` shows.
+    h.write(
+        "gh-secrets.json",
+        &serde_json::to_string_pretty(&json!({
+            "source": {"type": "bitwarden"},
+            "secrets": [{"name": "PLAIN"}],
+            "destinations": [],
+        }))
+        .unwrap(),
+    );
+    h.cmd().args(["list"]).assert().success().stdout(contains(
+        "PLAIN  (bitwarden item 'PLAIN', field 'password')",
+    ));
+}
+
 /// `check` works with a pure-argument pipeline too (no config file at all).
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn e2e_check_with_pure_args() {

--- a/tests/e2e_auth.rs
+++ b/tests/e2e_auth.rs
@@ -506,6 +506,93 @@ async fn e2e_passphrase_resolves_from_dotenv() {
         .stderr(contains("could not decrypt"));
 }
 
+/// A session minted for one vault is useless after the vault is recreated:
+/// the mismatched key is detected and the stale session file is deleted on
+/// sight, after which the (new) passphrase unlocks normally.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_stale_session_for_recreated_vault_is_dropped() {
+    let h = AuthHarness::new().await;
+    h.cmd().args(["auth", "github", "ghp_x"]).assert().success();
+    h.cmd().args(["auth", "unlock"]).assert().success();
+    let session = h.dir.path().join("home").join("session.json");
+    assert!(session.exists());
+
+    // Recreate the vault under a different passphrase. The old session file
+    // survives the raw delete, but its key no longer fits the new vault.
+    fs::remove_file(h.vault_file()).unwrap();
+    h.cmd()
+        .env("GH_SECRETS_PASSPHRASE", "a-brand-new-passphrase")
+        .args(["store", "set", "FOO", "fresh-vault-value"])
+        .assert()
+        .success();
+    assert!(session.exists(), "the stale session is still on disk");
+
+    // The next unlock tries the session, finds the key mismatch, drops it,
+    // and falls through to the new passphrase.
+    h.cmd()
+        .env("GH_SECRETS_PASSPHRASE", "a-brand-new-passphrase")
+        .args(["store", "list"])
+        .assert()
+        .success()
+        .stdout(contains("FOO"));
+    assert!(!session.exists(), "the mismatched session was deleted");
+}
+
+/// `auth lock` without an active session says so instead of pretending to
+/// lock something.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_auth_lock_without_session_reports_none() {
+    let h = AuthHarness::new().await;
+    h.cmd()
+        .args(["auth", "lock"])
+        .assert()
+        .success()
+        .stdout(contains("no active session"));
+}
+
+/// `auth clear --bitwarden` is the mirror of `--github`: it removes only the
+/// Bitwarden login and keeps the GitHub token.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_auth_clear_bitwarden_keeps_github() {
+    let h = AuthHarness::new().await;
+    h.cmd().args(["auth", "github", "ghp_x"]).assert().success();
+    h.cmd()
+        .args([
+            "auth",
+            "bitwarden",
+            "--client-id",
+            "user.x",
+            "--client-secret",
+            "cs",
+        ])
+        .assert()
+        .success();
+
+    h.cmd()
+        .args(["auth", "clear", "--bitwarden"])
+        .assert()
+        .success();
+    h.cmd()
+        .args(["auth", "status"])
+        .assert()
+        .success()
+        .stdout(contains("GitHub token: set (from stored config)"))
+        .stdout(contains("Bitwarden client id: not set"))
+        .stdout(contains("Bitwarden client secret: not set"));
+}
+
+/// An empty token is rejected before anything touches the vault.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_auth_github_rejects_empty_token() {
+    let h = AuthHarness::new().await;
+    h.cmd()
+        .args(["auth", "github", ""])
+        .assert()
+        .failure()
+        .stderr(contains("token cannot be empty"));
+    assert!(!h.vault_file().exists());
+}
+
 /// `auth unlock --days` controls the session length, reflected in `auth
 /// status`.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/tests/e2e_live_bitwarden.rs
+++ b/tests/e2e_live_bitwarden.rs
@@ -131,6 +131,43 @@ fn live_bw_field_selectors_extract_each_field() {
     }
 }
 
+/// `--default-field` changes what an unselected secret extracts, while an
+/// explicit `#field` selector still overrides it per secret.
+#[test]
+fn live_bw_default_field_flag_changes_the_default() {
+    skip_if_no_bw_live!();
+    let s = BwLiveSession::new("deffield");
+    let (user, pw, notes) = ("username-value-5", "password-value-5", "notes-value-5");
+    let item = s.seed_login("DEFF", user, pw, notes, ("C", "v"));
+
+    s.cmd()
+        .args([
+            "sync",
+            "--from",
+            "bitwarden",
+            "--default-field",
+            "notes",
+            "--to",
+            "env:out.env",
+            "--secret",
+            &format!("DEFAULTED={item}"),
+            "--secret",
+            &format!("OVERRIDDEN={item}#username"),
+        ])
+        .assert()
+        .success();
+
+    let body = dest_body(&s);
+    assert!(
+        body.contains(&format!("DEFAULTED=\"{notes}\"")),
+        "expected the default-field value (notes); got:\n{body}"
+    );
+    assert!(
+        body.contains(&format!("OVERRIDDEN=\"{user}\"")),
+        "expected the per-secret selector to override the default; got:\n{body}"
+    );
+}
+
 /// `source list` enumerates the vault by contacting Bitwarden directly, and
 /// prints item names but never a value.
 #[test]


### PR DESCRIPTION
Closes the e2e coverage gaps found by mapping the full feature surface against the existing suites. All additions drive the compiled binary; no production code changes.

## New coverage

**Wiremock suite (`tests/e2e.rs`)**
- GitHub 401/403/404/500 error mapping on both the public-key GET and the PUT, asserting the exact actionable stderr guidance.
- The 204 → "updated" report (previously every mock returned 201, so the created/updated wire distinction was never exercised).
- Malformed public-key rejection: wrong key length and non-JSON body.
- Partial-failure semantics: when one destination fails mid-sync, no state is recorded for any destination, so the re-run repushes; the earlier destination's write stands.
- State-file invariants: it holds hashes only (no plaintext), and deleting it merely forces a re-push.
- Out-of-band drift healing: tampered/deleted lines in an env destination and drifted local-store values are healed by `sync`, while `check` stays state-only by design; unrelated lines/comments survive every heal.
- Hostile values (quotes, `$`, backticks, newlines, tabs) round-trip env-destination → env-source with byte-identical canonical lines.
- Invalid `--from`/`--to`/`--secret` specs, malformed and unknown-type configs, and empty stdin to `store set` all error with the spec/file named.
- `list` renders the Bitwarden mapping (incl. `default_field` and per-secret `field` overrides) without contacting Bitwarden or needing credentials.

**Auth suite (`tests/e2e_auth.rs`)**
- A session left over from a recreated vault is detected as key-mismatched and deleted on sight, then the new passphrase unlocks normally.
- `auth lock` with no active session reports "no active session".
- `auth clear --bitwarden` is selective (mirror of the existing `--github` case).
- `auth github ""` is rejected before touching the vault.

**Live Bitwarden suite (`tests/e2e_live_bitwarden.rs`)**
- `--default-field` changes what an unselected secret extracts, while a per-secret `#field` selector still overrides it.

**Docs (`AGENTS.md`)**
- Suite descriptions updated to match, plus a note that the interactive passphrase-prompt paths are deliberately unit-level only (a PTY harness is flakier than the coverage is worth).

`just check` passes locally (68 tests). The live suites need CI's `GH_E2E_TOKEN` / `GH_SECRETS_BW_E2E_*` secrets to run for real — that's what this PR's CI runs validate.

https://claude.ai/code/session_01Kc8GNJQqjk4uZASwcKEudn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kc8GNJQqjk4uZASwcKEudn)_