### PR TITLE
fix: list supported selectors when a Bitwarden field selector is unknown

### DIFF
--- a/src/sources.rs
+++ b/src/sources.rs
@@ -557,7 +557,9 @@ pub fn extract_field(item: &Value, field: &str) -> Result<String> {
             }
             Err(anyhow!("no custom field named '{target}'"))
         }
-        other => Err(anyhow!("unsupported field selector '{other}'")),
+        other => Err(anyhow!(
+            "unsupported field selector '{other}' (supported: password, username, notes, fields.<NAME>)"
+        )),
     }
 }
 
@@ -596,7 +598,17 @@ mod tests {
     #[test]
     fn extract_unsupported_field_is_an_error() {
         let item = json!({});
-        assert!(extract_field(&item, "totp").is_err());
+        let err = extract_field(&item, "totp").unwrap_err().to_string();
+        assert!(
+            err.contains("unsupported field selector 'totp'"),
+            "got: {err}"
+        );
+        // The error must name the supported selectors so the user knows what
+        // to try instead of just learning their guess was wrong.
+        assert!(
+            err.contains("password") && err.contains("fields.<NAME>"),
+            "got: {err}"
+        );
     }
 
     /// Mock CLI that tracks calls so we can assert the source did login/unlock


### PR DESCRIPTION
## What

When a Bitwarden item is wired up with an unsupported `#FIELD` selector, the error named the bad selector but not the valid ones:

```
unsupported field selector 'totp'
```

Now it points at a concrete fix:

```
unsupported field selector 'totp' (supported: password, username, notes, fields.<NAME>)
```

This implements the repo's "every error names a concrete next action" standard, and naturally surfaces common near-misses — the singular `field.X`, a bare `fields`, or `#secret`. The unit test is tightened to assert the guidance is present.

## Scope

One error string + test in `src/sources.rs`. No behavior change beyond the message; no new deps; never prints a secret value.

---

This is also the change that exercises the new automatic-release pipeline end-to-end (release PR → CI → auto-merge → tag → binaries → crates.io).

🤖 Generated with [Claude Code](https://claude.com/claude-code)