### PR TITLE
fix: stop empty release-please pr output from killing the release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,12 @@ jobs:
         if: ${{ steps.release.outputs.pr }}
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-          PR_NUMBER: ${{ fromJson(steps.release.outputs.pr).number }}
+          # The runner evaluates step `env` templates even when `if` is false,
+          # so a bare fromJson() here fails the whole job on every run where
+          # release-please opened no PR (exactly the release-cut runs, which
+          # then never reach `build` — a release with no assets). Short-circuit
+          # so fromJson never sees an empty string.
+          PR_NUMBER: ${{ steps.release.outputs.pr && fromJson(steps.release.outputs.pr).number || '' }}
         run: |
           if [ -z "$GH_TOKEN" ]; then
             echo "RELEASE_PLEASE_TOKEN not set; leaving the release PR for a manual merge."


### PR DESCRIPTION
Every release-cut run of `release.yml` currently fails after tagging, so the GitHub Release is created but the `build` jobs never run and **no binaries get attached** — v1.0.1 shipped asset-less, which also breaks `live_install_script_downloads_and_verifies_release` (and therefore the `live-e2e` check) on every PR.

## Root cause

The auto-merge step added in #35 has:

```yaml
if: ${{ steps.release.outputs.pr }}
env:
  PR_NUMBER: ${{ fromJson(steps.release.outputs.pr).number }}
```

The Actions runner evaluates step `env` templates even when the step's `if` is false. On a run where release-please opens no PR — which is exactly the run that cuts a release — `pr` is empty, `fromJson('')` throws `The template is not valid (Line: 70)`, and the `release-please` job fails *after* the tag/Release already exist. `build` depends on that job, so it never runs. Both post-#35 release runs ([164f11a](https://github.com/nickderobertis/github-secrets/actions/runs/27349808567), [d7c6b46 / v1.0.1](https://github.com/nickderobertis/github-secrets/actions/runs/27351449138)) failed with this exact error; the one run where `pr` *was* set ([b8698aa](https://github.com/nickderobertis/github-secrets/actions/runs/27350998701)) succeeded — auto-merge itself works fine.

## Fix

Short-circuit the expression so `fromJson` never sees an empty string:

```yaml
PR_NUMBER: ${{ steps.release.outputs.pr && fromJson(steps.release.outputs.pr).number || '' }}
```

The `if` guard still skips the step on releasing runs; this just stops the env evaluation from killing the job first.

## Aftermath

Merging this (as `fix:`) makes release-please cut **v1.0.2 through the repaired pipeline**, which attaches binaries and unblocks `live-e2e` everywhere (v1.0.1's assets can't be backfilled: re-runs use the old workflow snapshot and `release_created` is false on re-run).

https://claude.ai/code/session_01Kc8GNJQqjk4uZASwcKEudn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kc8GNJQqjk4uZASwcKEudn)_