### PR TITLE
ci: stop release auto-merge step from failing the job on an empty PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,13 +67,25 @@ jobs:
         if: ${{ steps.release.outputs.pr }}
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-          PR_NUMBER: ${{ fromJson(steps.release.outputs.pr).number }}
+          # Pass the RAW pr JSON, not `fromJson(...).number`. A step's `env` is
+          # evaluated even when its `if:` is false, and `fromJson('')` throws
+          # ("Error reading JToken") — which would fail this whole job on every
+          # run with no open release PR (including the run that *cuts* a release
+          # and the runs after non-releasing merges), skipping build/publish.
+          # Parse the number with jq inside the script, where it only runs when
+          # `pr` is actually set.
+          RELEASE_PR: ${{ steps.release.outputs.pr }}
         run: |
           if [ -z "$GH_TOKEN" ]; then
             echo "RELEASE_PLEASE_TOKEN not set; leaving the release PR for a manual merge."
             exit 0
           fi
-          gh pr merge "$PR_NUMBER" --auto --squash --repo "$GITHUB_REPOSITORY"
+          pr_number=$(printf '%s' "$RELEASE_PR" | jq -r '.number')
+          if [ -z "$pr_number" ] || [ "$pr_number" = "null" ]; then
+            echo "No release PR number in release-please output; nothing to auto-merge."
+            exit 0
+          fi
+          gh pr merge "$pr_number" --auto --squash --repo "$GITHUB_REPOSITORY"
 
   build:
     name: build (${{ matrix.target }})

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -359,6 +359,15 @@ Allowed types: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`,
      tag/Release, and a push by `GITHUB_TOKEN` is ignored by Actions — it would
      strand the release at "PR merged, never tagged".
 
+  Gotcha that bit us once: the auto-merge step must read the PR number from the
+  raw `steps.release.outputs.pr` JSON **inside the run script** (via `jq`), not
+  as `PR_NUMBER: ${{ fromJson(steps.release.outputs.pr).number }}` in the step's
+  `env`. A step's `env` is evaluated even when its `if:` is false, so on every
+  run with no open release PR (the run that *cuts* a release, and runs after
+  non-releasing merges) `pr` is `""`, `fromJson('')` throws, and the whole
+  `release-please` job fails — which silently skips `build`/`crates-io` and
+  leaves an assetless, unpublished release.
+
   Auto-merge also requires the repo's **"Allow auto-merge"** setting to be on
   (Settings → General → Pull Requests) and a branch-protection rule with the
   required status checks; both are already configured on this repo. Set the PAT


### PR DESCRIPTION
## Bug

The `Enable auto-merge on the release PR` step (added in #35) read the PR number in its `env`:

```yaml
env:
  PR_NUMBER: ${{ fromJson(steps.release.outputs.pr).number }}
```

A step's `env` is evaluated **even when its `if:` is false**. On every `release` run with no open release PR — the run that *cuts* a release, and every run after a non-releasing merge — `steps.release.outputs.pr` is `""`, so `fromJson('')` throws `Error reading JToken` and **fails the whole `release-please` job**. The dependent `build` and `crates-io` jobs then `needs:`-skip, producing an assetless, unpublished release.

This is exactly what happened to **v1.0.1**: release-please cut the tag/Release, then the job crashed on the empty `pr`, so no binaries and no crates.io publish.

## Fix

Pass the **raw** `pr` JSON through `env` (an empty string is harmless) and parse the number with `jq` inside the run script, which only executes when a release PR is actually open:

```yaml
env:
  RELEASE_PR: ${{ steps.release.outputs.pr }}
run: |
  pr_number=$(printf '%s' "$RELEASE_PR" | jq -r '.number')
  [ -z "$pr_number" ] || [ "$pr_number" = "null" ] && exit 0
  gh pr merge "$pr_number" --auto --squash --repo "$GITHUB_REPOSITORY"
```

The happy path already worked (the #37-merge run enabled auto-merge on release PR #38, which auto-merged). This only fixes the empty-`pr` runs. Trap recorded in `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)