### PR TITLE
build: install cargo-nextest cross-platform in bootstrap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,15 @@ honor the never-print-a-value invariant.
 
 Use the `just` recipes; do not hand-roll equivalent commands.
 
-- `just bootstrap` — fetch the toolchain components and `cargo fetch`.
+- `just bootstrap` — add the `rustfmt`/`clippy` components, install
+  `cargo-nextest` for the host platform (`scripts/install-nextest.sh`:
+  idempotent, downloads the prebuilt binary from get.nexte.st for
+  Linux x86_64/arm64, macOS universal, or Windows, and heals a wrong-arch
+  binary), and `cargo fetch`. The gate runs through nextest (not `cargo
+  test`) because the inline test modules mutate process-global env vars and
+  need a process per test; the script is the one cross-platform way to get it.
+  CI installs nextest via a setup action *before* `bootstrap`, so the script
+  no-ops there.
 - `just check` — full quality gate: `cargo fmt --check`, `cargo clippy -D
   warnings`, `cargo nextest run` (unit + integration), and `test-e2e` (the
   wiremock-driven e2e suite plus a compile-and-skip pass of the live suite).

--- a/justfile
+++ b/justfile
@@ -7,9 +7,10 @@
 default:
     @just --list
 
-# Set up from a clean clone: fetch toolchain components + pre-fetch crates.
+# Set up from a clean clone: toolchain components, cargo-nextest, pre-fetch.
 bootstrap:
     rustup component add rustfmt clippy
+    sh scripts/install-nextest.sh
     cargo fetch --locked
 
 # Full quality gate: format check, clippy, unit + integration, and e2e.

--- a/scripts/install-nextest.sh
+++ b/scripts/install-nextest.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env sh
+# Install cargo-nextest for the host platform if a working one isn't present.
+#
+# `just check` runs the suite through cargo-nextest (the inline test modules
+# mutate process-global env vars, so they need a process per test — plain
+# `cargo test` races and fails). CI installs nextest via a setup action, but a
+# fresh local clone has nothing, and a binary copied from another machine is
+# the wrong architecture and dies with "cannot execute binary file". This
+# script gives every platform one reliable, idempotent install path; it is
+# wired into `just bootstrap`.
+#
+# Strategy: skip if a working nextest is already on PATH; otherwise download the
+# prebuilt binary for this host from get.nexte.st (fast, covers Linux x86_64 +
+# arm64, macOS universal, and Windows under a POSIX shell); fall back to
+# building from source if the platform is unrecognized or the download fails.
+set -eu
+
+if cargo nextest --version >/dev/null 2>&1; then
+    echo "cargo-nextest already installed ($(cargo nextest --version 2>/dev/null | head -1))."
+    exit 0
+fi
+
+bindir="${CARGO_HOME:-$HOME/.cargo}/bin"
+mkdir -p "$bindir"
+
+# Map host OS/arch to the matching get.nexte.st alias. macOS is a single
+# universal archive; Linux splits by arch; Windows ships a tar.gz for `tar`.
+url=""
+case "$(uname -s)" in
+    Darwin) url="https://get.nexte.st/latest/mac" ;;
+    Linux)
+        case "$(uname -m)" in
+            x86_64 | amd64) url="https://get.nexte.st/latest/linux" ;;
+            aarch64 | arm64) url="https://get.nexte.st/latest/linux-arm" ;;
+        esac
+        ;;
+    MINGW* | MSYS* | CYGWIN* | Windows_NT) url="https://get.nexte.st/latest/windows-tar" ;;
+esac
+
+if [ -n "$url" ] && command -v curl >/dev/null 2>&1; then
+    echo "Installing cargo-nextest from $url …"
+    tmp="$(mktemp)"
+    # Download to a file first so a failed fetch (curl -f) is caught before we
+    # try to untar it — piping curl|tar would mask the HTTP error.
+    if curl -LsSf "$url" -o "$tmp" && tar -xzf "$tmp" -C "$bindir"; then
+        rm -f "$tmp"
+        echo "Installed cargo-nextest to $bindir ($(cargo nextest --version 2>/dev/null | head -1))."
+        exit 0
+    fi
+    rm -f "$tmp"
+    echo "Prebuilt download failed; building cargo-nextest from source instead." >&2
+else
+    echo "No prebuilt target for this host ($(uname -s)/$(uname -m)); building from source." >&2
+fi
+
+cargo install cargo-nextest --locked
+echo "Installed cargo-nextest from source ($(cargo nextest --version 2>/dev/null | head -1))."


### PR DESCRIPTION
## Problem

`just check` runs the suite through **cargo-nextest** (the inline test modules mutate process-global env vars like `GH_SECRETS_PASSPHRASE`, so they need a process per test — plain `cargo test` races and fails). CI installs nextest via `taiki-e/install-action`, but a fresh **local** clone had no install path. A nextest binary copied from another machine ran as the **wrong architecture** (`cannot execute binary file` — a Linux x86-64 ELF on an arm64 Mac), so `just check` died at the test step.

## Fix

`scripts/install-nextest.sh` — idempotent, cross-platform:
- Skips if a working `cargo nextest` is already on PATH.
- Otherwise downloads the prebuilt binary for the host from **get.nexte.st** (Linux x86_64/arm64, macOS universal, Windows `tar`), falling back to `cargo install cargo-nextest --locked`.
- Heals a broken/wrong-arch binary by overwriting it.

Wired into `just bootstrap`. CI's setup action still installs nextest *before* `bootstrap`, so the script no-ops there (CI stays fast/cached).

## Verified locally (arm64 macOS)

- Installer detected the broken binary and reinstalled the macOS **universal** binary (`Mach-O universal: [x86_64] [arm64]`).
- `just bootstrap` re-run → script reports "already installed" (idempotent).
- `just check` → **68 tests, 68 passed, 0 skipped** (including the env-racing `destinations` test that fails under `cargo test`).

No release bump (`build:`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)